### PR TITLE
BUGFIX: Add width to propertlist for truncation

### DIFF
--- a/Resources/Private/JavaScript/src/components/App.tsx
+++ b/Resources/Private/JavaScript/src/components/App.tsx
@@ -19,7 +19,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         // TODO: Find a way to not calculate height to allow scrolling in main grid area
         height: `calc(100vh - 40px * 4 - 21px)`,
         gridTemplateRows: 'auto 1fr',
-        gridTemplateColumns: selectionMode ? '250px 1fr' : '250px 1fr 250px',
+        gridTemplateColumns: theme.size.sidebarWidth + ' 1fr ' + `${!selectionMode ? theme.size.sidebarWidth : ''}`,
         gridTemplateAreas: selectionMode
             ? `
             "left top"

--- a/Resources/Private/JavaScript/src/components/App.tsx
+++ b/Resources/Private/JavaScript/src/components/App.tsx
@@ -19,7 +19,9 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         // TODO: Find a way to not calculate height to allow scrolling in main grid area
         height: `calc(100vh - 40px * 4 - 21px)`,
         gridTemplateRows: 'auto 1fr',
-        gridTemplateColumns: theme.size.sidebarWidth + ' 1fr ' + `${!selectionMode ? theme.size.sidebarWidth : ''}`,
+        gridTemplateColumns: selectionMode
+            ? theme.size.sidebarWidth + ' 1fr'
+            : theme.size.sidebarWidth + ' 1fr ' + theme.size.sidebarWidth,
         gridTemplateAreas: selectionMode
             ? `
             "left top"

--- a/Resources/Private/JavaScript/src/components/Pagination.tsx
+++ b/Resources/Private/JavaScript/src/components/Pagination.tsx
@@ -9,7 +9,7 @@ import { MediaUiTheme } from '../interfaces';
 const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
     pagination: {
         display: 'grid',
-        gridTemplateColumns: '250px 1fr 250px',
+        gridTemplateColumns: theme.size.sidebarWidth + ' 1fr ' + theme.size.sidebarWidth,
         position: 'fixed',
         bottom: 0,
         left: 0,

--- a/Resources/Private/JavaScript/src/components/SideBarRight/Inspector/PropertyList.tsx
+++ b/Resources/Private/JavaScript/src/components/SideBarRight/Inspector/PropertyList.tsx
@@ -11,9 +11,10 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
             backgroundColor: theme.colors.alternatingBackground,
             color: 'white',
             fontWeight: 'bold',
-            padding: '8px 8px 0',
+            padding: `${theme.spacing.half} ${theme.spacing.half} 0`,
             textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap'
+            whiteSpace: 'nowrap',
+            width: `calc(${theme.size.sidebarWidth} - ${theme.spacing.full})`
         },
         '& dd': {
             backgroundColor: theme.colors.alternatingBackground,
@@ -22,7 +23,8 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
             padding: theme.spacing.half,
             textOverflow: 'ellipsis',
             overflowX: 'hidden',
-            whiteSpace: 'nowrap'
+            whiteSpace: 'nowrap',
+            width: `calc(${theme.size.sidebarWidth} - ${theme.spacing.full})`
         }
     }
 }));

--- a/Resources/Private/JavaScript/src/core/MediaUiTheme.tsx
+++ b/Resources/Private/JavaScript/src/core/MediaUiTheme.tsx
@@ -14,6 +14,10 @@ const mediaUiTheme: MediaUiTheme = {
         ...config.fontSize,
         large: '18px'
     },
+    size: {
+        ...config.size,
+        sidebarWidth: '250px'
+    },
     colors: {
         primary: config.colors.primaryBlue,
         text: config.colors.contrastBright,

--- a/Resources/Private/JavaScript/src/interfaces/MediaUiTheme.ts
+++ b/Resources/Private/JavaScript/src/interfaces/MediaUiTheme.ts
@@ -10,6 +10,9 @@ export default interface MediaUiTheme {
         base: string;
         small: string;
     };
+    size: {
+        sidebarWidth: string;
+    };
     colors: {
         success: string;
         warn: string;


### PR DESCRIPTION
The text-overflow with ellipsis always needs a defined width. Therefore we should provide that.
I added the sidebar width as constant and use some variables in the property list to get a defined width.

![Screenshot 2020-06-24 at 18 29 08](https://user-images.githubusercontent.com/1014126/85594870-9d3ad300-b648-11ea-9583-9f38a9314d1b.png)


Fixes: #41