### PR TITLE
BUGFIX: Remove array type in variable

### DIFF
--- a/Classes/GraphQL/Context/AssetSourceContext.php
+++ b/Classes/GraphQL/Context/AssetSourceContext.php
@@ -48,7 +48,7 @@ class AssetSourceContext extends BaseContext
     /**
      * @var array<AssetSourceInterface>
      */
-    protected array $assetSources;
+    protected $assetSources;
 
     /**
      * @return void

--- a/Classes/GraphQL/Resolver/Type/AssetResolver.php
+++ b/Classes/GraphQL/Resolver/Type/AssetResolver.php
@@ -51,7 +51,7 @@ class AssetResolver implements ResolverInterface
     /**
      * @var array<AssetInterface>
      */
-    protected array $localAssetData = [];
+    protected $localAssetData = [];
 
     /**
      * @param AssetProxyInterface $assetProxy


### PR DESCRIPTION
To be compatible with all php versions for neos 5.2
we need to remove the array type in the class variables.
That just works with php 7.4 and neos 5.2 is 7.2 and newer.

**What I did**
Removed the array type in the two classes.

**How to verify it**
Just load the site with the installed package, after clearing the cache.

![Screenshot 2020-06-26 at 09 27 42](https://user-images.githubusercontent.com/1014126/85831888-4f7cb280-b78f-11ea-879d-dec1d82df932.png)
