### PR TITLE
BUGFIX: Prevent showing large images outside of lightbox

### DIFF
--- a/patches/react-image-lightbox+5.1.1.patch
+++ b/patches/react-image-lightbox+5.1.1.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/react-image-lightbox/dist/index.es.js b/node_modules/react-image-lightbox/dist/index.es.js
+index 57f5a0d..9794558 100644
+--- a/node_modules/react-image-lightbox/dist/index.es.js
++++ b/node_modules/react-image-lightbox/dist/index.es.js
+@@ -317,10 +317,6 @@ function (_Component) {
+       var nextX = x;
+       var windowWidth = getWindowWidth();
+ 
+-      if (width > windowWidth) {
+-        nextX += (windowWidth - width) / 2;
+-      }
+-
+       var scaleFactor = zoom * (targetWidth / width);
+       return {
+         transform: "translate3d(".concat(nextX, "px,").concat(y, "px,0) scale3d(").concat(scaleFactor, ",").concat(scaleFactor, ",1)")


### PR DESCRIPTION
Introduce patch for the lightbox library to prevent moving a large asset outside of the lightbox area.

Resolves: #47 
