### PR TITLE
BUGFIX: prevent inspector overflow

### DIFF
--- a/Resources/Private/JavaScript/BackendModule/src/components/SideBarRight/Inspector/InspectorContainer.tsx
+++ b/Resources/Private/JavaScript/BackendModule/src/components/SideBarRight/Inspector/InspectorContainer.tsx
@@ -5,6 +5,7 @@ import { createUseMediaUiStyles, MediaUiTheme } from '@media-ui/core/src';
 const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
     inspector: {
         display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1fr)',
         gridAutoRows: 'auto',
         gridGap: theme.spacing.full,
         '& input, & textarea': {


### PR DESCRIPTION
Fixes: https://github.com/Flowpack/media-ui/issues/51

**What I did**

If a certain inspector element is wider than the inspector's width, it would cause overflow and clipping of overflown content on all elements in the inspector.

**How I did it**

I've given an explicit width to the grid column and set it to `minmax(0, 1fr)`. The default value for column width is `auto` which is in turn equivalent to `minmax(min-content, max-content)`. And `min-content` is equal from the largest minimum width of either of inspector children. So if a certain element has a fixed width, it makes the inspector grid column to be equal to its width which makes all other properly sized elements to be stretched and overflow as well.

**How to verify it**

Watch out for this slight clipping here:
![image](https://user-images.githubusercontent.com/837032/115405600-123e5100-a1f7-11eb-9430-19b733420d77.png)

