### PR TITLE
BUGFIX: Layout changes for creation dialog

### DIFF
--- a/Configuration/Settings.Neos.yaml
+++ b/Configuration/Settings.Neos.yaml
@@ -34,3 +34,7 @@ Neos:
         stylesheets:
           Flowpack.Media.Ui:AssetEditor:
             resource: resource://Flowpack.Media.Ui/Public/AssetEditor/Plugin.css
+          # Plugin.css is missing the styles for the Lightbox used for Asset Previews,
+          # so we have to include the main bundle as well
+          Flowpack.Media.Ui:Assets:
+            resource: resource://Flowpack.Media.Ui/Public/Assets/main.bundle.css

--- a/Resources/Private/JavaScript/asset-preview/src/components/AssetPreview.tsx
+++ b/Resources/Private/JavaScript/asset-preview/src/components/AssetPreview.tsx
@@ -17,12 +17,33 @@ const useStyles = createUseMediaUiStyles({
     },
 });
 
+const useLightBoxContainer = (defaultContainer: null | Element = null) => {
+    const lightBoxContainerRef = React.useRef<null | Element>(defaultContainer);
+
+    React.useEffect(() => {
+        if (defaultContainer === null) {
+            const newLightBoxContainer = document.createElement('div');
+            newLightBoxContainer.setAttribute('data-ignore_click_outside', 'true');
+
+            document.body.appendChild(newLightBoxContainer);
+            lightBoxContainerRef.current = newLightBoxContainer;
+
+            return () => newLightBoxContainer.remove();
+        }
+
+        lightBoxContainerRef.current = defaultContainer;
+    }, [defaultContainer]);
+
+    return lightBoxContainerRef;
+};
+
 export default function AssetPreview() {
     const classes = useStyles();
     const theme = useMediaUiTheme();
-    const { containerRef, assets } = useMediaUi();
+    const { containerRef, isInNodeCreationDialog, assets } = useMediaUi();
     const [selectedAssetForPreview, setSelectedAssetForPreview] = useRecoilState(selectedAssetForPreviewState);
     const { asset } = useAssetQuery(selectedAssetForPreview);
+    const lightBoxContainer = useLightBoxContainer(isInNodeCreationDialog ? null : containerRef.current);
 
     const [prevAsset, nextAsset] = useMemo(() => {
         if (!asset) return [null, null];
@@ -40,7 +61,7 @@ export default function AssetPreview() {
     return (
         <Lightbox
             reactModalStyle={{ overlay: { zIndex: theme.lightboxZIndex } }}
-            reactModalProps={{ parentSelector: () => containerRef.current }}
+            reactModalProps={{ parentSelector: () => lightBoxContainer.current }}
             wrapperClassName={classes.lightbox}
             mainSrc={asset.previewUrl}
             mainSrcThumbnail={asset.thumbnailUrl}

--- a/Resources/Private/JavaScript/core/src/provider/MediaUiProvider.tsx
+++ b/Resources/Private/JavaScript/core/src/provider/MediaUiProvider.tsx
@@ -12,6 +12,7 @@ interface MediaUiProviderProps {
     children: React.ReactElement;
     dummyImage: string;
     selectionMode?: boolean;
+    isInNodeCreationDialog?: boolean;
     containerRef: React.RefObject<HTMLDivElement>;
     onAssetSelection?: (localAssetIdentifier: string) => void;
     featureFlags: FeatureFlags;
@@ -23,6 +24,7 @@ interface MediaUiProviderValues {
     handleDeleteAsset: (asset: Asset) => Promise<boolean>;
     handleSelectAsset: (assetIdentity: AssetIdentity) => void;
     selectionMode: boolean;
+    isInNodeCreationDialog: boolean;
     assets: Asset[];
     refetchAssets: () => void;
     featureFlags: FeatureFlags;
@@ -35,6 +37,7 @@ export function MediaUiProvider({
     children,
     dummyImage,
     selectionMode = false,
+    isInNodeCreationDialog = false,
     onAssetSelection = null,
     containerRef,
     featureFlags,
@@ -109,6 +112,7 @@ export function MediaUiProvider({
                 handleDeleteAsset,
                 handleSelectAsset,
                 selectionMode,
+                isInNodeCreationDialog,
                 assets,
                 refetchAssets,
                 featureFlags,

--- a/Resources/Private/JavaScript/media-module/src/components/App.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/App.tsx
@@ -19,10 +19,12 @@ import { CreateTagDialog, UploadDialog, CreateAssetCollectionDialog } from './Di
 import { AssetPreview } from '../../../asset-preview/src';
 
 const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
-    container: ({ selectionMode }) => ({
+    container: ({ selectionMode, isInNodeCreationDialog }) => ({
         display: 'grid',
         // TODO: Find a way to not calculate height to allow scrolling in main grid area
-        height: `calc(100vh - 48px - 61px - 41px)`, // Remove top bar, body padding and bottom bar
+        height: isInNodeCreationDialog
+            ? `calc(100% - 61px - 8px)` // Remove bottom bar and add padding
+            : `calc(100vh - 48px - 61px - 41px)`, // Remove top bar, body padding and bottom bar
         gridTemplateRows: '40px 1fr',
         gridTemplateColumns: selectionMode
             ? theme.size.sidebarWidth + ' 1fr'
@@ -87,13 +89,13 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
 }));
 
 const App = () => {
-    const { selectionMode, containerRef } = useMediaUi();
+    const { selectionMode, isInNodeCreationDialog, containerRef } = useMediaUi();
     const showUploadDialog = useRecoilValue(uploadDialogVisibleState);
     const { visible: showCreateTagDialog } = useRecoilValue(createTagDialogState);
     const { visible: showCreateAssetCollectionDialog } = useRecoilValue(createAssetCollectionDialogState);
     const showAssetUsagesModal = useRecoilValue(assetUsageDetailsModalState);
     const showSimilarAssetsModal = useRecoilValue(similarAssetsModalState);
-    const classes = useStyles({ selectionMode });
+    const classes = useStyles({ selectionMode, isInNodeCreationDialog });
 
     return (
         <div className={classes.container} ref={containerRef}>

--- a/Resources/Private/JavaScript/media-module/src/components/BottomBar/BottomBar.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/BottomBar/BottomBar.tsx
@@ -1,29 +1,30 @@
 import * as React from 'react';
 import { useMemo } from 'react';
 
-import { createUseMediaUiStyles, MediaUiTheme } from '@media-ui/core/src';
+import { createUseMediaUiStyles, MediaUiTheme, useMediaUi } from '@media-ui/core/src';
 import { ClipboardToggle } from '@media-ui/feature-clipboard/src';
 
 import AssetCount from './AssetCount/AssetCount';
 import Pagination from './Pagination/Pagination';
 
 const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
-    bottomBar: {
+    bottomBar: ({ isInNodeCreationDialog }) => ({
         display: 'grid',
-        gridTemplateColumns: '350px 1fr 350px',
+        gridTemplateColumns: isInNodeCreationDialog ? 'repeat(3, 1fr)' : '350px 1fr 350px',
         gridGap: theme.spacing.goldenUnit,
         position: 'fixed',
-        bottom: 0,
-        left: 0,
-        right: 0,
+        bottom: isInNodeCreationDialog ? -16 : 0,
+        left: isInNodeCreationDialog ? -16 : 0,
+        right: isInNodeCreationDialog ? -16 : 0,
         borderTop: `1px solid ${theme.colors.border}`,
         backgroundColor: theme.colors.moduleBackground,
         zIndex: theme.paginationZIndex,
-    },
+    }),
 }));
 
 const BottomBar: React.FC = () => {
-    const classes = useStyles();
+    const { isInNodeCreationDialog } = useMediaUi();
+    const classes = useStyles({ isInNodeCreationDialog });
 
     const components = useMemo(() => [AssetCount, Pagination, ClipboardToggle], []);
 

--- a/Resources/Private/JavaScript/media-module/src/components/BottomBar/Pagination/Pagination.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/BottomBar/Pagination/Pagination.tsx
@@ -19,6 +19,7 @@ const useStyles = createUseMediaUiStyles({
         justifySelf: 'center',
         listStyleType: 'none',
         textAlign: 'center',
+        padding: 0,
     },
     ellipsis: {
         lineHeight: '2.4rem',

--- a/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateAssetCollectionDialog.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateAssetCollectionDialog.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { useRecoilState } from 'recoil';
 
-import { Button, TextInput, Label, Dialog } from '@neos-project/react-ui-components';
+import { Button, TextInput, Label } from '@neos-project/react-ui-components';
 
 import { useIntl, createUseMediaUiStyles, useNotify } from '@media-ui/core/src';
 import { useCreateAssetCollection } from '@media-ui/core/src/hooks';
 
 import { useCallback } from 'react';
 import { createAssetCollectionDialogState } from '../../state';
+
+import { Dialog } from './Dialog';
 
 const useStyles = createUseMediaUiStyles(() => ({
     formBody: {

--- a/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateTagDialog.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateTagDialog.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import { useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { Button, Dialog, Label, TextInput } from '@neos-project/react-ui-components';
+import { Button, Label, TextInput } from '@neos-project/react-ui-components';
 
 import { useIntl, createUseMediaUiStyles, useNotify } from '@media-ui/core/src';
 import { useCreateTag, useSelectedAssetCollection } from '@media-ui/core/src/hooks';
 
 import { createTagDialogState } from '../../state';
+
+import { Dialog } from './Dialog';
 
 const useStyles = createUseMediaUiStyles(() => ({
     formBody: {

--- a/Resources/Private/JavaScript/media-module/src/components/Dialogs/Dialog.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Dialogs/Dialog.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import { Dialog as NeosUiDialog } from '@neos-project/react-ui-components';
+
+//
+// @TODO: Remove this once https://github.com/neos/neos-ui/issues/2925 is solved.
+//
+export const Dialog: React.FC<any> = (props) => {
+    const dialogRef = React.useRef<React.ReactInstance>();
+
+    React.useEffect(() => {
+        if (dialogRef.current) {
+            const section = ReactDOM.findDOMNode(dialogRef.current) as null | HTMLElement; // eslint-disable-line react/no-find-dom-node
+            section?.firstElementChild?.setAttribute('data-ignore_click_outside', 'true');
+        }
+    }, [dialogRef]);
+
+    return <NeosUiDialog {...props} ref={dialogRef} />;
+};

--- a/Resources/Private/JavaScript/media-module/src/components/Dialogs/UploadDialog.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Dialogs/UploadDialog.tsx
@@ -3,13 +3,15 @@ import { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useRecoilState } from 'recoil';
 
-import { Button, Icon, Dialog } from '@neos-project/react-ui-components';
+import { Button, Icon } from '@neos-project/react-ui-components';
 
 import { useIntl, createUseMediaUiStyles, MediaUiTheme, useMediaUi, useNotify } from '@media-ui/core/src';
 import { useConfigQuery, useUploadFiles } from '@media-ui/core/src/hooks';
 
 import { humanFileSize } from '../../helper';
 import { uploadDialogVisibleState } from '../../state';
+
+import { Dialog } from './Dialog';
 
 const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
     uploadArea: {

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListView.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListView.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useCallback } from 'react';
 import { useSetRecoilState } from 'recoil';
 
-import { useIntl, createUseMediaUiStyles, MediaUiTheme } from '@media-ui/core/src';
+import { useIntl, createUseMediaUiStyles, MediaUiTheme, useMediaUi } from '@media-ui/core/src';
 import { AssetIdentity } from '@media-ui/core/src/interfaces';
 import { useSelectAsset } from '@media-ui/core/src/hooks';
 import { selectedAssetForPreviewState } from '@media-ui/feature-asset-preview/src';
@@ -10,8 +10,9 @@ import { selectedAssetForPreviewState } from '@media-ui/feature-asset-preview/sr
 import { ListViewItem } from './index';
 
 const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
-    listView: {
+    listView: ({ isInNodeCreationDialog }) => ({
         overflowY: 'scroll',
+        height: isInNodeCreationDialog ? '100%' : 'auto',
         '& table': {
             borderSpacing: '0 1px',
             width: '100%',
@@ -28,7 +29,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
                 },
             },
         },
-    },
+    }),
 }));
 
 interface ListViewProps {
@@ -36,7 +37,8 @@ interface ListViewProps {
 }
 
 const ListView: React.FC<ListViewProps> = ({ assetIdentities }: ListViewProps) => {
-    const classes = useStyles();
+    const { isInNodeCreationDialog } = useMediaUi();
+    const classes = useStyles({ isInNodeCreationDialog });
     const { translate } = useIntl();
     const setSelectedAssetForPreview = useSetRecoilState(selectedAssetForPreviewState);
     const selectAsset = useSelectAsset();

--- a/Resources/Private/JavaScript/media-selection-screen/src/MediaSelectionScreen.tsx
+++ b/Resources/Private/JavaScript/media-selection-screen/src/MediaSelectionScreen.tsx
@@ -46,17 +46,20 @@ interface MediaSelectionScreenProps {
     type: 'assets' | 'images';
     onComplete: (localAssetIdentifier: string) => void;
     isLeftSideBarHidden: boolean;
+    isNodeCreationDialogOpen: boolean;
     toggleSidebar: () => void;
     addFlashMessage: (title: string, message: string, severity?: string, timeout?: number) => void;
 }
 
 interface MediaSelectionScreenState {
     initialLeftSideBarHiddenState: boolean;
+    initialNodeCreationDialogOpenState: boolean;
 }
 
 @connect(
     $transform({
         isLeftSideBarHidden: $get('ui.leftSideBar.isHidden'),
+        isNodeCreationDialogOpen: $get('ui.nodeCreationDialog.isOpen'),
     }),
     {
         addFlashMessage: actions.UI.FlashMessages.add,
@@ -76,23 +79,25 @@ export default class MediaSelectionScreen extends React.PureComponent<
         super(props);
         this.state = {
             initialLeftSideBarHiddenState: false,
+            initialNodeCreationDialogOpenState: false,
         };
     }
 
     componentDidMount() {
-        const { isLeftSideBarHidden, toggleSidebar } = this.props;
+        const { isLeftSideBarHidden, isNodeCreationDialogOpen, toggleSidebar } = this.props;
         this.setState({
             initialLeftSideBarHiddenState: isLeftSideBarHidden,
+            initialNodeCreationDialogOpenState: isNodeCreationDialogOpen,
         });
-        if (!isLeftSideBarHidden) {
+        if (!isLeftSideBarHidden && !isNodeCreationDialogOpen) {
             toggleSidebar();
         }
     }
 
     componentWillUnmount() {
         const { isLeftSideBarHidden, toggleSidebar } = this.props;
-        const { initialLeftSideBarHiddenState } = this.state;
-        if (initialLeftSideBarHiddenState !== isLeftSideBarHidden) {
+        const { initialLeftSideBarHiddenState, initialNodeCreationDialogOpenState } = this.state;
+        if (initialLeftSideBarHiddenState !== isLeftSideBarHidden && !initialNodeCreationDialogOpenState) {
             toggleSidebar();
         }
     }
@@ -160,8 +165,10 @@ export default class MediaSelectionScreen extends React.PureComponent<
             error: (title, message = '') => addFlashMessage(title, message, 'error'),
         };
 
+        const isInNodeCreationDialog = this.state.initialNodeCreationDialogOpenState;
+
         return (
-            <div style={{ transform: 'translateZ(0)', height: '100%', padding: '1rem' }}>
+            <div style={{ transform: 'translateZ(0)', height: '100%', padding: isInNodeCreationDialog ? 0 : '1rem' }}>
                 <IntlProvider translate={this.translate}>
                     <NotifyProvider notificationApi={Notification}>
                         <ApolloProvider client={client}>
@@ -170,6 +177,7 @@ export default class MediaSelectionScreen extends React.PureComponent<
                                     dummyImage={dummyImage}
                                     onAssetSelection={(localAssetIdentifier) => onComplete(localAssetIdentifier)}
                                     selectionMode={true}
+                                    isInNodeCreationDialog={isInNodeCreationDialog}
                                     containerRef={containerRef}
                                     featureFlags={featureFlags}
                                 >


### PR DESCRIPTION
This PR implements adjustments in order to integrate the new Media UI seamlessly as a secondary editor within the NodeCreationDialog (implemented in https://github.com/neos/neos-ui/pull/2870).

The changes made consist of slight CSS changes as well as some fixes for compatibility issues:

### Make MediaUiProvider aware of NodeCreationDialog

First of all, the MediaUiProvider needed the information that it is being used within the NodeCreationDialog. The condition to determine this however is a little flimsy right now, due to current limitations of the Main UI.

This PR is checking, whether the NodeCreationDialog is open, because we can assume that if `componentDidMount` of
`MediaSelectionScreen` is being called while the dialog is open, the component definitely must be rendered within the dialog, since the dialog is modal and thus prevents all other interaction from happening.

We might have more than 1 instance of `MediaSelectionScreen` at once - one in a SecondaryInspector screen and
one in the NodeCreationDialog. With the solution in this PR, these two do not interfere (verified by manual testing). This only works because the condition happens to have the implication described above.

Furthermore, this PR prevents the left side bar of the Neos UI from closing, when the `MediaSelectionScreen` is being rendered within the NodeCreationDialog. Also, the padding around the `MediaSelectionScreen` is removed, since the NodeCreationDialog already provides sufficient padding.



#### Notes for the future

- The Neos.Ui should provide a more official way to let `Editor`-components know, whether they are being rendered inside the NodeCreationDialog

### Adjust BottomBar for NodeCreationDialog

|Before |After  |
--- | ---
| ![BottomBar-before](https://user-images.githubusercontent.com/2522299/126078077-075ed47c-12bd-411f-b92d-a6219a563677.png) | ![BottomBar-after](https://user-images.githubusercontent.com/2522299/126078081-2bf74653-9207-46a7-8b6b-fb3f798e1e9f.png) |

The BottomBar is positioned in a way that makes it look as if it is part of the dialog.

The grid layout is adjusted, so that each column takes up as much space as is needed, as opposed to the left-most and right-most columns reserving 350px worth of space.

### Adjust ListView for NodeCreationDialog

|Before |After  |
--- | ---
| ![Listview-before](https://user-images.githubusercontent.com/2522299/126078154-163a43fc-7db3-4683-a18f-74ffa8b3c124.png) | ![ListView-after](https://user-images.githubusercontent.com/2522299/126078158-f91e0a53-0ec6-4089-b7e7-6bac244e3138.png) |

The height of the ListView is adjusted, so that it doesn't overflow the height of the reserved space for secondary editors. Doing so prevents a second scrollbar from appearing when users switch to the ListView.

### Adjust App Layout to NodeCreationDialog

|Before |After  |
--- | ---
| ![App-before](https://user-images.githubusercontent.com/2522299/126078221-46c51896-d9e6-497e-87e5-d3deab575c8f.png) | ![App-after](https://user-images.githubusercontent.com/2522299/126078225-df47b4e3-9fdf-4602-8f73-f23124aa823d.png) |

The height of the App Layout is calculated in a way that it compensates for the bottom bar and the padding provided by the NodeCreationDialog for secondary editors.

### Remove default left padding from Pagination list 

To adjust the Pagination list better to a more narrow bottom bar, I removed the default left padding of the `<ol>`:

![padding](https://user-images.githubusercontent.com/2522299/126078389-b942c605-b492-44cd-a074-1389b5a212bb.png)

I assumed, that the padding wasn't intentional to begin with, so I put no condition to that. The padding is gone for all cases.

### Prevent any media ui action from closing the NodeCreationDialog accidentally

This one's a bit tricky. Basically, Neos.Ui can't actually stack dialogs on top of each other. It happens to work optically, but due to the click-outside handling of the Neos.Ui Dialog Component, each dialog stacked on top of another one will close immediately when interacted with.

I opened an issue in Neos.Ui with some more info: https://github.com/neos/neos-ui/issues/2925

So, the workaround I implemented to address this is probably a little questionable. It adds a custom decorator component for the Neos UI Dialog that sets the attribute `data-ignore_click_outside="true"` on the dialog container, so that it is excluded from click-outside handling. Clicking on the second overlay still closes both dialogs though.

This solution is crude and relies on a deprecated ReactDOM-API (`ReactDOM.findDOMNode` to be exact - I had to put a `eslint-disable-line` at that as well...). But for the time being, it'll at least make the inner dialogs usable in most cases.

#### Notes for the future

- Once https://github.com/neos/neos-ui/issues/2925 is solved, this workaround needs to go

### Make AssetPreview compatible with NodeCreationDialog

This addresses two problems:

1. The styles for the Lightbox component were missing from the Plugin.css bundle. I solved this by including the main bundle for the Neos.Ui as well.
2. The Lightbox was constrained to the area of the NodeCreationDialog reserved for secondary editors. I solved this by creating a separate Lightbox container on-demand when the Lightbox is rendered inside the NodeCreationDialog.

#### Notes for the Future

- The Lightbox styles are still bundled inside the Plugin.css, but with hashed class names (CSS modules). To remove them the need to be excluded from the build somehow and this will likely require a change in Neos.Ui.
- Including the main bundle for the Main UI also introduces a lot of redundancy. There might be a way to split out a separate CSS bundle for The Lightbox only using Parcel. Another way might be to leave them out of the bundling process and just copy them from `node_modules` to `Public`. Not sure what's the best choice of action here :sweat_smile: 

closes: #68