### PR TITLE
BUGFIX: Make localId nullable in GraphQL schema

### DIFF
--- a/Resources/Private/GraphQL/schema.root.graphql
+++ b/Resources/Private/GraphQL/schema.root.graphql
@@ -146,7 +146,7 @@ An asset (Image, Document, Video or Audio)
 """
 type Asset {
     id: AssetId!
-    localId: LocalAssetId!
+    localId: LocalAssetId
     assetSource: AssetSource!
     imported: Boolean!
     isInUse: Boolean!

--- a/Resources/Private/JavaScript/core/src/interfaces/Asset.ts
+++ b/Resources/Private/JavaScript/core/src/interfaces/Asset.ts
@@ -10,7 +10,7 @@ type AssetType = 'Asset';
 export default interface Asset extends GraphQlEntity {
     __typename: AssetType;
     readonly id: string;
-    readonly localId: string;
+    readonly localId?: string;
     assetSource: AssetSource;
     imported: boolean;
 


### PR DESCRIPTION
This makes the `localId` on `Asset` nullable, to have the GraphQL schema match the PHP side of affairs.

Fixes #92
