### PR TITLE
FEATURE: get lastModified date from remote proxy

### DIFF
--- a/Classes/GraphQL/Resolver/Type/AssetResolver.php
+++ b/Classes/GraphQL/Resolver/Type/AssetResolver.php
@@ -215,7 +215,7 @@ class AssetResolver implements ResolverInterface
     {
         $localAssetData = $assetSourceContext->getAssetForProxy($assetProxy);
         if (!$localAssetData instanceof Asset) {
-            return null;
+            return $assetProxy->getLastModified() ? $assetProxy->getLastModified()->format(DATE_W3C) : null;
         }
         return $localAssetData->getLastModified() ? $localAssetData->getLastModified()->format(DATE_W3C) : null;
     }

--- a/Classes/GraphQL/Resolver/Type/AssetResolver.php
+++ b/Classes/GraphQL/Resolver/Type/AssetResolver.php
@@ -213,11 +213,7 @@ class AssetResolver implements ResolverInterface
      */
     public function lastModified(AssetProxyInterface $assetProxy, array $variables, AssetSourceContext $assetSourceContext): ?string
     {
-        $localAssetData = $assetSourceContext->getAssetForProxy($assetProxy);
-        if (!$localAssetData instanceof Asset) {
-            return $assetProxy->getLastModified() ? $assetProxy->getLastModified()->format(DATE_W3C) : null;
-        }
-        return $localAssetData->getLastModified() ? $localAssetData->getLastModified()->format(DATE_W3C) : null;
+        return $assetProxy->getLastModified() ? $assetProxy->getLastModified()->format(DATE_W3C) : null;
     }
 
     /**


### PR DESCRIPTION
**What I did**
If an asset from a remote proxy is not imported, the last modified date is not used and defaults to 1.1.1970, 01:00:00 . With this PR, the last modified date from the remote asset source is used. 

**How I did it**
If there is no local asset, the function getLastModified is used to fetch the latest modify date. This function already exists in the AssetProxyInterface so it has to be implemented. I do not understand why the workaround with the localAssetData is used, so perhaps this can be generally replaced with the method from the interface? 

**How to verify it**
After integrating an asset source with remote assets (like https://github.com/flownative/neos-canto), the modified date does not default to 1.1.1970, 01:00:00. 
 
Closes #97 