### PR TITLE
FEATURE: Make maximumFileUploadLimit configurable

### DIFF
--- a/Classes/GraphQL/Resolver/Type/QueryResolver.php
+++ b/Classes/GraphQL/Resolver/Type/QueryResolver.php
@@ -95,6 +95,12 @@ class QueryResolver implements ResolverInterface
     protected $persistenceManager;
 
     /**
+     * @Flow\InjectConfiguration(package="Flowpack.Media.Ui")
+     * @var array
+     */
+    protected $settings;
+
+    /**
      * Returns total count of asset proxies in the given asset source
      *
      * @param $_
@@ -284,7 +290,7 @@ class QueryResolver implements ResolverInterface
      */
     protected function getMaximumFileUploadLimit(): int
     {
-        return (int)ini_get('upload_max_filesize') ?: 1;
+        return (int)($this->settings['maximumFileUploadLimit'] ?? 10);
     }
 
     /**

--- a/Classes/Service/UsageDetailsService.php
+++ b/Classes/Service/UsageDetailsService.php
@@ -295,8 +295,6 @@ class UsageDetailsService
     /**
      * Returns all assets which have no usage reference provided by `Flowpack.EntityUsage`
      *
-     * @param int $limit
-     * @param int $offset
      * @return array<AssetInterface>
      * @throws Exception
      */
@@ -341,9 +339,6 @@ class UsageDetailsService
 
     /**
      * Returns a DQL clause filtering any implementation of AssetVariantInterface
-     *
-     * @return string
-     * @var string $alias
      */
     protected function getAssetVariantFilterClause(string $alias): string
     {
@@ -357,7 +352,6 @@ class UsageDetailsService
     /**
      * Returns number of assets which have no usage reference provided by `Flowpack.EntityUsage`
      *
-     * @return int
      * @throws Exception
      */
     public function getUnusedAssetCount(): int

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,0 +1,4 @@
+Flowpack:
+  Media:
+    Ui:
+      maximumFileUploadLimit: 10


### PR DESCRIPTION
Currently the maximumFileUploadLimit is equal to upload_max_filesize which results in weird numbers for larger max filesizes. This change makes that value configurable with a value of 10 as default.