### PR TITLE
Bugfix: Do not allow empty Tags in create-tag Dialog 

### DIFF
--- a/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateTagDialog.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateTagDialog.tsx
@@ -66,7 +66,7 @@ const CreateTagDialog: React.FC = () => {
                     type="text"
                     value={dialogState.label}
                     onChange={setLabel}
-                    onEnterKey={handleCreate}
+                    onEnterKey={createPossible ? handleCreate : null}
                 />
             </div>
         </Dialog>

--- a/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateTagDialog.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateTagDialog.tsx
@@ -23,7 +23,7 @@ const CreateTagDialog: React.FC = () => {
     const Notify = useNotify();
     const selectedAssetCollection = useSelectedAssetCollection();
     const [dialogState, setDialogState] = useRecoilState(createTagDialogState);
-    const createPossible = true;
+    const createPossible = !!(dialogState.label && dialogState.label.trim());
     const { createTag } = useCreateTag();
 
     const handleRequestClose = useCallback(() => setDialogState({ visible: false, label: '' }), [setDialogState]);


### PR DESCRIPTION
**What I did**
When creating new Tags, the UI allows for empty tags to be created and then throws an error. 

**How I did it**
Just like in the UploadDialog I disabled the create button until there is an actual value entered in the CreateTag Dialog. Also, the enter button on the keyboard does not work anymore until the field is not empty anymore.

**How to verify it**
When creating a new Tag, the 'create' button is disabled and 'enter' does not create  new tag until an actual value is entered into the textfield. 