### PR TITLE
Bugfix: Change Label width

### DIFF
--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListView.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListView.tsx
@@ -34,33 +34,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         backgroundColor: 'var(--grayDark)',
         top: '0px',
         zIndex: '1',
-    },
-    table: {
-        tableLayout: 'fixed',
-    },
-    previewColumn: {
-        extend: 'tableHeader',
-        width: '40px',
-    },
-    labelColumn: {
-        extend: 'tableHeader',
-    },
-    lastModifiedColumn: {
-        extend: 'tableHeader',
-        width: '150px',
-    },
-    fileSizeColumn: {
-        extend: 'tableHeader',
-        width: '75px',
-    },
-    mediaTypeColumn: {
-        extend: 'tableHeader',
-        width: '100px',
-    },
-    actionsColumn: {
-        extend: 'tableHeader',
-        width: '160px',
-    },
+    }
 }));
 
 interface ListViewProps {
@@ -87,21 +61,21 @@ const ListView: React.FC<ListViewProps> = ({ assetIdentities }: ListViewProps) =
 
     return (
         <section className={classes.listView}>
-            <table className={classes.table}>
+            <table>
                 <thead>
                     <tr>
-                        <th className={classes.previewColumn} />
-                        <th className={classes.labelColumn}>{translate('thumbnailView.header.name', 'Name')}</th>
-                        <th className={classes.lastModifiedColumn}>
+                        <th className={classes.tableHeader} />
+                        <th className={classes.tableHeader}>{translate('thumbnailView.header.name', 'Name')}</th>
+                        <th className={classes.tableHeader}>
                             {translate('thumbnailView.header.lastModified', 'Last Modified')}
                         </th>
-                        <th className={classes.fileSizeColumn}>
+                        <th className={classes.tableHeader}>
                             {translate('thumbnailView.header.fileSize', 'File size')}
                         </th>
-                        <th className={classes.mediaTypeColumn}>
+                        <th className={classes.tableHeader}>
                             {translate('thumbnailView.header.mediaType', 'Type')}
                         </th>
-                        <th className={classes.actionsColumn} />
+                        <th className={classes.tableHeader} />
                     </tr>
                 </thead>
                 <tbody>

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListView.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListView.tsx
@@ -34,7 +34,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         backgroundColor: 'var(--grayDark)',
         top: '0px',
         zIndex: '1',
-    }
+    },
 }));
 
 interface ListViewProps {
@@ -72,9 +72,7 @@ const ListView: React.FC<ListViewProps> = ({ assetIdentities }: ListViewProps) =
                         <th className={classes.tableHeader}>
                             {translate('thumbnailView.header.fileSize', 'File size')}
                         </th>
-                        <th className={classes.tableHeader}>
-                            {translate('thumbnailView.header.mediaType', 'Type')}
-                        </th>
+                        <th className={classes.tableHeader}>{translate('thumbnailView.header.mediaType', 'Type')}</th>
                         <th className={classes.tableHeader} />
                     </tr>
                 </thead>

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListView.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListView.tsx
@@ -11,7 +11,6 @@ import { ListViewItem } from './index';
 
 const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
     listView: ({ isInNodeCreationDialog }) => ({
-        overflowY: 'scroll',
         height: isInNodeCreationDialog ? '100%' : 'auto',
         '& table': {
             borderSpacing: '0 1px',
@@ -30,6 +29,38 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
             },
         },
     }),
+    tableHeader: {
+        position: 'sticky',
+        backgroundColor: 'var(--grayDark)',
+        top: '0px',
+        zIndex: '1',
+    },
+    table: {
+        tableLayout: 'fixed',
+    },
+    previewColumn: {
+        extend: 'tableHeader',
+        width: '40px',
+    },
+    labelColumn: {
+        extend: 'tableHeader',
+    },
+    lastModifiedColumn: {
+        extend: 'tableHeader',
+        width: '150px',
+    },
+    fileSizeColumn: {
+        extend: 'tableHeader',
+        width: '75px',
+    },
+    mediaTypeColumn: {
+        extend: 'tableHeader',
+        width: '100px',
+    },
+    actionsColumn: {
+        extend: 'tableHeader',
+        width: '160px',
+    },
 }));
 
 interface ListViewProps {
@@ -56,15 +87,21 @@ const ListView: React.FC<ListViewProps> = ({ assetIdentities }: ListViewProps) =
 
     return (
         <section className={classes.listView}>
-            <table>
+            <table className={classes.table}>
                 <thead>
                     <tr>
-                        <th />
-                        <th>{translate('thumbnailView.header.name', 'Name')}</th>
-                        <th>{translate('thumbnailView.header.lastModified', 'Last Modified')}</th>
-                        <th>{translate('thumbnailView.header.fileSize', 'File size')}</th>
-                        <th>{translate('thumbnailView.header.mediaType', 'Type')}</th>
-                        <th />
+                        <th className={classes.previewColumn} />
+                        <th className={classes.labelColumn}>{translate('thumbnailView.header.name', 'Name')}</th>
+                        <th className={classes.lastModifiedColumn}>
+                            {translate('thumbnailView.header.lastModified', 'Last Modified')}
+                        </th>
+                        <th className={classes.fileSizeColumn}>
+                            {translate('thumbnailView.header.fileSize', 'File size')}
+                        </th>
+                        <th className={classes.mediaTypeColumn}>
+                            {translate('thumbnailView.header.mediaType', 'Type')}
+                        </th>
+                        <th className={classes.actionsColumn} />
                     </tr>
                 </thead>
                 <tbody>

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
@@ -57,7 +57,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         extend: 'textColumn',
         userSelect: 'text',
         '& > *': {
-            width: '200px',
+            minWidth: '200px',
         },
     },
     lastModifiedColumn: {

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
@@ -33,6 +33,8 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         whiteSpace: 'nowrap',
         userSelect: 'none',
         cursor: 'pointer',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
         '& > *': {
             verticalAlign: 'middle',
         },
@@ -57,7 +59,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         extend: 'textColumn',
         userSelect: 'text',
         '& > *': {
-            minWidth: '200px',
+            width: '100%',
         },
     },
     lastModifiedColumn: {
@@ -70,8 +72,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         extend: 'textColumn',
     },
     actionsColumn: {
-        display: 'flex',
-        justifyContent: 'flex-end',
+        textAlign: 'right',
     },
 }));
 
@@ -112,7 +113,7 @@ const ListViewItem: React.FC<ListViewItemProps> = ({ assetIdentity, onSelect }: 
             <td className={classes.fileSizeColumn} onClick={onSelectItem}>
                 {asset && humanFileSize(asset.file.size)}
             </td>
-            <td className={classes.mediaTypeColumn} onClick={onSelectItem}>
+            <td className={classes.mediaTypeColumn} onClick={onSelectItem} title={asset?.file.mediaType}>
                 {asset?.file.mediaType}
             </td>
             <td className={classes.actionsColumn}>

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
@@ -33,9 +33,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         whiteSpace: 'nowrap',
         userSelect: 'none',
         cursor: 'pointer',
-        textOverflow: 'ellipsis',
         width:'1px',
-        overflow: 'hidden',
         '& > *': {
             verticalAlign: 'middle',
         },

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
@@ -34,6 +34,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         userSelect: 'none',
         cursor: 'pointer',
         textOverflow: 'ellipsis',
+        width:'1px',
         overflow: 'hidden',
         '& > *': {
             verticalAlign: 'middle',
@@ -57,6 +58,10 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
     },
     labelColumn: {
         extend: 'textColumn',
+        display: 'table',
+        tableLayout: 'fixed',
+        width: '100%',
+        lineHeight: theme.spacing.goldenUnit,
         userSelect: 'text',
         '& > *': {
             width: '100%',
@@ -72,6 +77,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         extend: 'textColumn',
     },
     actionsColumn: {
+        extend: 'textColumn',
         textAlign: 'right',
     },
 }));
@@ -113,7 +119,7 @@ const ListViewItem: React.FC<ListViewItemProps> = ({ assetIdentity, onSelect }: 
             <td className={classes.fileSizeColumn} onClick={onSelectItem}>
                 {asset && humanFileSize(asset.file.size)}
             </td>
-            <td className={classes.mediaTypeColumn} onClick={onSelectItem} title={asset?.file.mediaType}>
+            <td className={classes.mediaTypeColumn} onClick={onSelectItem}>
                 {asset?.file.mediaType}
             </td>
             <td className={classes.actionsColumn}>

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
@@ -33,7 +33,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
         whiteSpace: 'nowrap',
         userSelect: 'none',
         cursor: 'pointer',
-        width:'1px',
+        width: '1px',
         '& > *': {
             verticalAlign: 'middle',
         },


### PR DESCRIPTION
closes #111 

**What I did**
Currently with very long file names, the filename is not fully shown in Listview. This happens even if there is space to show the whole filename. I changed that to show the full filename. 

**How I did it**
I changed the fixed width of the label to a minwidth. 
This shows more of the label but with very long labels this creates a horizontal scrollbar. Perhaps changing up the whole table with fixed widths could solve this. 

**How to verify it**
Long filenames in listview are now fully shown if the window is big enough. 

Old behavior: 

![Bildschirmfoto 2022-01-04 um 11 51 35](https://user-images.githubusercontent.com/91674611/148058644-3a5707e8-3895-4661-9131-34d47bb57bb6.png)

New Behavior: 

![Bildschirmfoto 2022-01-04 um 14 03 59](https://user-images.githubusercontent.com/91674611/148063333-48c4fad7-b411-4c81-ab5e-c9cf6523a58d.png)