### PR TITLE
Bugfix: Do not allow empty collection name in create dialog

### DIFF
--- a/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateAssetCollectionDialog.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Dialogs/CreateAssetCollectionDialog.tsx
@@ -22,7 +22,7 @@ const CreateAssetCollectionDialog = () => {
     const { translate } = useIntl();
     const Notify = useNotify();
     const [dialogState, setDialogState] = useRecoilState(createAssetCollectionDialogState);
-    const createPossible = true;
+    const createPossible = !!(dialogState.title && dialogState.title.trim());
     const { createAssetCollection } = useCreateAssetCollection();
 
     const handleRequestClose = useCallback(() => setDialogState({ title: '', visible: false }), [setDialogState]);
@@ -68,7 +68,7 @@ const CreateAssetCollectionDialog = () => {
                     type="text"
                     value={dialogState.title}
                     onChange={setTitle}
-                    onEnterKey={handleCreate}
+                    onEnterKey={createPossible ? handleCreate : null}
                 />
             </div>
         </Dialog>


### PR DESCRIPTION
**What I did**
When creating a new collection, the UI allows empty Collection names. 

**How I did it**
I disabled the create button until there is an actual value entered in the Dialog. Also, the enter button on the keyboard does not work anymore until the field is not empty anymore.
This is basically like https://github.com/Flowpack/media-ui/pull/107 , just for Collections

**How to verify it**
When creating a new Collection, the 'create' button is disabled and 'enter' does not create new Collection until an actual value is entered into the textfield.