### PR TITLE
BUGFIX: Very long media-types create a horizontal scrollbar 

### DIFF
--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
@@ -73,6 +73,9 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
     },
     mediaTypeColumn: {
         extend: 'textColumn',
+        maxWidth: '150px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
     },
     actionsColumn: {
         extend: 'textColumn',
@@ -117,7 +120,7 @@ const ListViewItem: React.FC<ListViewItemProps> = ({ assetIdentity, onSelect }: 
             <td className={classes.fileSizeColumn} onClick={onSelectItem}>
                 {asset && humanFileSize(asset.file.size)}
             </td>
-            <td className={classes.mediaTypeColumn} onClick={onSelectItem}>
+            <td className={classes.mediaTypeColumn} onClick={onSelectItem} title={asset?.file.mediaType}>
                 {asset?.file.mediaType}
             </td>
             <td className={classes.actionsColumn}>

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
@@ -73,7 +73,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
     },
     mediaTypeColumn: {
         extend: 'textColumn',
-        maxWidth: '150px',
+        maxWidth: '100px',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
     },


### PR DESCRIPTION
closes #116 

**What I did**
After Uploading a .pptx file the Type-column in the Media UI becomes very long and creates a horizontal scrollbar on smaller screens. 

**How I did it**
To make sure the media type does not take up too much space I have added a max-width of 100px. This is somehow generic and seemed like a good width to me where all smaller mime-types like svg, pdf, mp4, png are still fully displayed. To give people the opportunity to still see the full mime-type I added a title-tag that will be visible on hover 

**How to verify it**
After uploading a file with a long mime-type the Type is cut off after 100px. On hover the title-tag is shown. 

![Bildschirmfoto 2022-02-03 um 16 24 21](https://user-images.githubusercontent.com/91674611/152376850-60b86f2d-baa3-41fd-ad8e-e313d8fbee67.png)

![Bildschirmfoto 2022-02-03 um 16 47 52](https://user-images.githubusercontent.com/91674611/152377316-f2f58e21-b3b4-4e86-a9a0-1ed2137ad63c.png)

