### PR TITLE
FEATURE: Support mediatype constriants

### DIFF
--- a/Resources/Private/JavaScript/core/package.json
+++ b/Resources/Private/JavaScript/core/package.json
@@ -4,7 +4,8 @@
   "license": "GNU GPLv3",
   "private": true,
   "dependencies": {
-    "pubsub-js": "^1.9.3"
+    "pubsub-js": "^1.9.3",
+    "matcher": "^5.0.0"
   },
   "devDependencies": {
     "@types/pubsub-js": "^1.8.2"

--- a/Resources/Private/JavaScript/core/typings/DateTime.d.ts
+++ b/Resources/Private/JavaScript/core/typings/DateTime.d.ts
@@ -1,0 +1,1 @@
+type DateTimeFormatOption = 'short' | 'long' | 'narrow' | 'numeric';

--- a/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/ListViewItem.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useRecoilState } from 'recoil';
+
+import { Icon } from '@neos-project/react-ui-components';
 
 import { createUseMediaUiStyles, MediaUiTheme, useMediaUi } from '@media-ui/core/src';
 import { AssetIdentity } from '@media-ui/core/src/interfaces';
@@ -46,8 +48,9 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
             display: 'block',
             width: '100%',
             height: theme.spacing.goldenUnit,
-            '& img': {
-                display: 'block',
+            textAlign: 'center',
+            '& img, & svg': {
+                display: 'inline-block',
                 width: '100%',
                 height: '100%',
                 objectFit: 'contain',
@@ -83,7 +86,7 @@ const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
     },
 }));
 
-const dateFormatOptions = {
+const dateFormatOptions: Record<string, DateTimeFormatOption> = {
     weekday: 'short',
     year: 'numeric',
     month: 'short',
@@ -97,18 +100,23 @@ interface ListViewItemProps {
 
 const ListViewItem: React.FC<ListViewItemProps> = ({ assetIdentity, onSelect }: ListViewItemProps) => {
     const classes = useStyles();
-    const { dummyImage } = useMediaUi();
+    const { dummyImage, isAssetSelectable } = useMediaUi();
     const { asset, loading } = useAssetQuery(assetIdentity);
     const [selectedAssetId] = useRecoilState(selectedAssetIdState);
     const isSelected = selectedAssetId?.assetId === assetIdentity.assetId;
 
+    const canBeSelected = useMemo(() => isAssetSelectable(asset), [asset, isAssetSelectable]);
     const onSelectItem = useCallback(() => onSelect(assetIdentity, isSelected), [onSelect, assetIdentity, isSelected]);
 
     return (
         <tr className={[classes.listViewItem, isSelected ? classes.selected : ''].join(' ')}>
             <td className={classes.previewColumn} onClick={onSelectItem}>
                 <picture>
-                    <img src={asset?.thumbnailUrl || dummyImage} alt={asset?.label} width={40} height={36} />
+                    {canBeSelected ? (
+                        <img src={asset?.thumbnailUrl || dummyImage} alt={asset?.label} width={40} height={36} />
+                    ) : (
+                        <Icon icon="ban" color="error" />
+                    )}
                 </picture>
             </td>
             <td className={classes.labelColumn} onClick={onSelectItem}>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -9,6 +9,10 @@
             <trans-unit id="uploadDialog.maxFileSize" xml:space="preserve" approved="yes">
                 <source>Maximum file size is {size} and file limit is {limit}</source>
             </trans-unit>
+
+            <trans-unit id="action.selectAsset.invalidType.message" xml:space="preserve" approved="yes">
+                <source>You can only select any of the following types: {types}</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5687,6 +5687,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
+
 escodegen@^1.11.0, escodegen@^1.11.1, escodegen@^1.9.0:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
@@ -9015,6 +9020,13 @@ match-url-wildcard@0.0.4:
   integrity sha512-R1XhQaamUZPWLOPtp4ig5j+3jctN+skhgRmEQTUamMzmNtRG69QEirQs0NZKLtHMR7tzWpmtnS4Eqv65DcgXUA==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+matcher@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/matcher/-/matcher-5.0.0.tgz#cd82f1c7ae7ee472a9eeaf8ec7cac45e0fe0da62"
+  integrity sha512-s2EMBOWtXFc8dgqvoAzKJXxNHibcdJMV0gwqKUaw9E2JBJuGUK7DrNKrA6g/i+v72TT16+6sVm5mS3thaMLQUw==
+  dependencies:
+    escape-string-regexp "^5.0.0"
 
 math-random@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
**What I did**

The selection screen now disallows selecting assets not matching the constraints defined in the nodetype yaml definition.

The disallowed assets are also rendered slightly different to make the differentation visible.

Resolves: #14

**How I did it**

**How to verify it**

Use a nodetype property like this to set constraints for asset sources and media types :

```
  properties:
    image:
      ui:
        inspector:
          editorOptions:
            accept: 'image/jpeg,image/gif'
            constraints:
              mediaTypes:
                - 'image/jpeg'
              assetSources:
                - 'neos'
                - 'pexels'
```

This results in a a limited selection for the asset sources and invalid assets are grayed out and unelectable:

<img width="1084" alt="Bildschirmfoto 2022-03-14 um 10 59 29" src="https://user-images.githubusercontent.com/596967/158149458-72029849-085c-45ff-af67-df881c2b9b20.png">

