### PR TITLE
BUGFIX: Prevent items in left sidebar from overlapping on small window heights

### DIFF
--- a/Resources/Private/JavaScript/media-module/src/components/Presentation/Column.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Presentation/Column.tsx
@@ -6,7 +6,7 @@ import { createUseMediaUiStyles, MediaUiTheme } from '@media-ui/core/src';
 const useStyles = createUseMediaUiStyles((theme: MediaUiTheme) => ({
     column: {
         display: 'grid',
-        gridAutoRows: 'minmax(0, min-content)',
+        gridAutoRows: 'minmax(min-content, max-content)',
         gridGap: theme.spacing.full,
         overflowY: 'auto',
         overflowX: 'hidden',


### PR DESCRIPTION
This fixes the following overlap issue in the left sidebar for small window heights that also broke an e2e test:

![OverlapError](https://user-images.githubusercontent.com/596967/204378378-61e98d95-c65c-49b1-9bf8-4b593ea9e871.png)
