### PR TITLE
BUGFIX: Close clipboard screen when an asset source or asset collection gets selected

### DIFF
--- a/Resources/Private/JavaScript/media-module/src/components/SideBarLeft/AssetSourceList.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/SideBarLeft/AssetSourceList.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { useSetRecoilState } from 'recoil';
 
 import { Headline } from '@neos-project/react-ui-components';
 
 import { useIntl, createUseMediaUiStyles, MediaUiTheme } from '@media-ui/core/src';
 import { useAssetSourcesQuery, useSelectAssetSource } from '@media-ui/core/src/hooks';
+import { clipboardVisibleState } from '@media-ui/feature-clipboard/src';
 
 import { IconLabel } from '../Presentation';
 
@@ -36,6 +38,15 @@ export default function AssetSourceList() {
     const { assetSources } = useAssetSourcesQuery();
     const { translate } = useIntl();
     const [selectedAssetSource, setSelectedAssetSource] = useSelectAssetSource();
+    const setClipboardVisibleState = useSetRecoilState(clipboardVisibleState);
+
+    const handleSelectAssetSource = React.useCallback(
+        (assetSourceId: string) => {
+            setSelectedAssetSource(assetSourceId);
+            setClipboardVisibleState(false);
+        },
+        [setSelectedAssetSource, setClipboardVisibleState]
+    );
 
     // We don't show the source selection if there is only one
     if (!assetSources || assetSources.length < 2) return null;
@@ -54,7 +65,7 @@ export default function AssetSourceList() {
                 >
                     <a
                         className={selectedAssetSource?.id === assetSource.id ? classes.itemSelected : null}
-                        onClick={() => setSelectedAssetSource(assetSource.id)}
+                        onClick={() => handleSelectAssetSource(assetSource.id)}
                     >
                         {assetSource.id === 'neos' ? translate('assetsource.local', 'Local') : assetSource.label}
                     </a>

--- a/Resources/Private/JavaScript/media-module/src/components/SideBarLeft/Tree/AssetCollectionTree.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/SideBarLeft/Tree/AssetCollectionTree.tsx
@@ -5,6 +5,7 @@ import { useSetRecoilState } from 'recoil';
 import { IconButton, Tree, Headline } from '@neos-project/react-ui-components';
 
 import { selectedAssetCollectionIdState, selectedAssetIdState, selectedTagIdState } from '@media-ui/core/src/state';
+import { AssetCollection } from '@media-ui/core/src/interfaces';
 import { useIntl, createUseMediaUiStyles, MediaUiTheme, useNotify } from '@media-ui/core/src';
 import {
     useAssetCollectionsQuery,
@@ -17,6 +18,7 @@ import {
     useSelectTag,
     useTagsQuery,
 } from '@media-ui/core/src/hooks';
+import { clipboardVisibleState } from '@media-ui/feature-clipboard/src';
 
 import AssetCollectionTreeNode from './AssetCollectionTreeNode';
 import TagTreeNode from './TagTreeNode';
@@ -55,6 +57,7 @@ const AssetCollectionTree = () => {
     const selectedTag = useSelectedTag();
     const setSelectedAssetId = useSetRecoilState(selectedAssetIdState);
     const setSelectedTagId = useSetRecoilState(selectedTagIdState);
+    const setClipboardVisibleState = useSetRecoilState(clipboardVisibleState);
     const { tags } = useTagsQuery();
     const { assetCollections } = useAssetCollectionsQuery();
     const [selectedAssetSource] = useSelectAssetSource();
@@ -119,6 +122,14 @@ const AssetCollectionTree = () => {
         deleteAssetCollection,
     ]);
 
+    const handleSelectAssetCollection = React.useCallback(
+        (assetCollection: AssetCollection) => {
+            selectAssetCollection(assetCollection);
+            setClipboardVisibleState(false);
+        },
+        [selectAssetCollection, setClipboardVisibleState]
+    );
+
     if (!selectedAssetSource?.supportsCollections) return null;
 
     return (
@@ -148,7 +159,7 @@ const AssetCollectionTree = () => {
                     label={translate('assetCollectionList.showAll', 'All')}
                     title={translate('assetCollectionList.showAll.title', 'Show assets for all collections')}
                     level={1}
-                    onClick={selectAssetCollection}
+                    onClick={handleSelectAssetCollection}
                     assetCollection={null}
                     collapsedByDefault={false}
                 >
@@ -166,7 +177,7 @@ const AssetCollectionTree = () => {
                     <AssetCollectionTreeNode
                         key={index}
                         assetCollection={assetCollection}
-                        onClick={selectAssetCollection}
+                        onClick={handleSelectAssetCollection}
                         level={1}
                         isActive={assetCollection.title == selectedAssetCollection?.title}
                         isFocused={assetCollection.title == selectedAssetCollection?.title && !selectedTag}


### PR DESCRIPTION
solves: #139

**The Problem**

When the clipboard screen is open, it is still possible to select an asset source or an asset collection via the left side bar. But since the clipboard screen remains open, it seems as if nothing happened after the selection.

**The Solution**

I used the `clipboardVisibleState` recoil state from `@media-ui/feature-clipboard` to explicitly close the clipboard screen whenever an asset source or an asset collection gets selected via the left side bar.
