### PR TITLE
WIP FEATURE: Faster asset loading

### DIFF
--- a/Classes/Controller/ImageApiController.php
+++ b/Classes/Controller/ImageApiController.php
@@ -24,7 +24,7 @@ class ImageApiController extends ActionController
     protected $assetSourceService;
 
     /**
-     * @throws StopActionException
+     * @throws StopActionException|UnsupportedRequestTypeException
      */
     public function thumbnailAction(string $assetProxyId, string $assetSourceId): void
     {
@@ -33,7 +33,7 @@ class ImageApiController extends ActionController
     }
 
     /**
-     * @throws StopActionException
+     * @throws StopActionException|UnsupportedRequestTypeException
      */
     public function previewAction(string $assetProxyId, string $assetSourceId): void
     {

--- a/Classes/Controller/ImageApiController.php
+++ b/Classes/Controller/ImageApiController.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\Controller;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Flow\Mvc\Exception\StopActionException;
+use Neos\Media\Domain\Service\AssetSourceService;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class ImageApiController extends ActionController
+{
+
+    /**
+     * @Flow\Inject
+     * @var AssetSourceService
+     */
+    protected $assetSourceService;
+
+    /**
+     * @throws StopActionException
+     */
+    public function thumbnailAction(string $assetProxyId, string $assetSourceId): void
+    {
+        $assetSources = $this->assetSourceService->getAssetSources();
+        // Get AssetSource matching the given id
+        $assetSource = $assetSources[$assetSourceId] ?? null;
+
+        if (!$assetSource) {
+            $this->throwStatus(404, 'AssetSource not found');
+        }
+
+        $assetProxy = $assetSource->getAssetProxyRepository()->getAssetProxy($assetProxyId);
+
+        if (!$assetProxy) {
+            $this->throwStatus(404, 'AssetProxy not found');
+        }
+
+        $this->redirectToUri($assetProxy->getThumbnailUri());
+    }
+
+    /**
+     * @throws StopActionException
+     */
+    public function previewAction(string $assetProxyId, string $assetSourceId): void
+    {
+        $assetSources = $this->assetSourceService->getAssetSources();
+        // Get AssetSource matching the given id
+        $assetSource = $assetSources[$assetSourceId] ?? null;
+
+        if (!$assetSource) {
+            $this->throwStatus(404, 'AssetSource not found');
+        }
+
+        $assetProxy = $assetSource->getAssetProxyRepository()->getAssetProxy($assetProxyId);
+
+        if (!$assetProxy) {
+            $this->throwStatus(404, 'AssetProxy not found');
+        }
+
+        $this->redirectToUri($assetProxy->getPreviewUri());
+    }
+}

--- a/Classes/GraphQL/Resolver/Type/AssetResolver.php
+++ b/Classes/GraphQL/Resolver/Type/AssetResolver.php
@@ -57,19 +57,11 @@ class AssetResolver implements ResolverInterface
      */
     protected $assetService;
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @return string|null
-     */
     public function id(AssetProxyInterface $assetProxy): ?string
     {
         return $assetProxy->getIdentifier();
     }
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @return string|null
-     */
     public function localId(AssetProxyInterface $assetProxy): ?string
     {
         return $assetProxy->getLocalAssetIdentifier();
@@ -77,11 +69,6 @@ class AssetResolver implements ResolverInterface
 
     /**
      * Returns the title of the associated local asset data or the label of the proxy as fallback
-     *
-     * @param AssetProxyInterface $assetProxy
-     * @param array $variables
-     * @param AssetSourceContext $assetSourceContext
-     * @return string|null
      */
     public function label(AssetProxyInterface $assetProxy, array $variables, AssetSourceContext $assetSourceContext): ?string
     {
@@ -94,11 +81,6 @@ class AssetResolver implements ResolverInterface
 
     /**
      * Returns true if the asset is at least used once
-     *
-     * @param AssetProxyInterface $assetProxy
-     * @param array $variables
-     * @param AssetSourceContext $assetSourceContext
-     * @return bool|null
      */
     public function isInUse(AssetProxyInterface $assetProxy, array $variables, AssetSourceContext $assetSourceContext): ?bool
     {
@@ -110,11 +92,6 @@ class AssetResolver implements ResolverInterface
 
     /**
      * Returns the caption of the associated local asset data
-     *
-     * @param AssetProxyInterface $assetProxy
-     * @param array $variables
-     * @param AssetSourceContext $assetSourceContext
-     * @return string|null
      */
     public function caption(AssetProxyInterface $assetProxy, array $variables, AssetSourceContext $assetSourceContext): ?string
     {
@@ -122,22 +99,27 @@ class AssetResolver implements ResolverInterface
         return $localAssetData instanceof Asset ? $localAssetData->getCaption() : null;
     }
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @return bool
-     */
     public function imported(AssetProxyInterface $assetProxy): bool
     {
         // TODO: Find better way to make sure the asset originates from somewhere outside Neos
-        return (bool)$assetProxy->getLocalAssetIdentifier() && $assetProxy->getAssetSource()->getIdentifier() !== 'neos';
+        return $assetProxy->getLocalAssetIdentifier() && $assetProxy->getAssetSource()->getIdentifier() !== 'neos';
     }
 
     /**
+     * Returns a matching icon uri for the given asset-proxy
      *
-     * Returns a matching icon uri for the given assetproxy
-     *
-     * @param AssetProxyInterface $assetProxy
-     * @return array
+     * @return array{
+     *     extension: string,
+     *     mediaType: string,
+     *     typeIcon: array{
+     *         width: int,
+     *         height: int,
+     *         url: string,
+     *         alt: string
+     *     },
+     *     size: int,
+     *     url: string
+     * }
      */
     public function file(AssetProxyInterface $assetProxy): array
     {
@@ -165,10 +147,6 @@ class AssetResolver implements ResolverInterface
 
     /**
      * Returns the iptc properties for assetproxies that implement the interface
-     *
-     * @param AssetProxyInterface $assetProxy
-     * @param array $variables
-     * @return string|null
      */
     public function iptcProperty(AssetProxyInterface $assetProxy, array $variables): ?string
     {
@@ -177,10 +155,8 @@ class AssetResolver implements ResolverInterface
     }
 
     /**
-     * Returns the iptc properties for assetproxies that implement the interface
-     *
-     * @param AssetProxyInterface $assetProxy
-     * @return array
+     * Returns the iptc properties for asset-proxies that implement the interface
+     * @return array{propertyName: string, value: string}[]
      */
     public function iptcProperties(AssetProxyInterface $assetProxy): array
     {
@@ -193,34 +169,19 @@ class AssetResolver implements ResolverInterface
         return [];
     }
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @param array $variables
-     * @param AssetSourceContext $assetSourceContext
-     * @return string|null
-     */
     public function copyrightNotice(AssetProxyInterface $assetProxy, array $variables, AssetSourceContext $assetSourceContext): ?string
     {
         $localAssetData = $assetSourceContext->getAssetForProxy($assetProxy);
         return $localAssetData instanceof Asset ? $localAssetData->getCopyrightNotice() : null;
     }
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @param array $variables
-     * @param AssetSourceContext $assetSourceContext
-     * @return string|null
-     */
     public function lastModified(AssetProxyInterface $assetProxy, array $variables, AssetSourceContext $assetSourceContext): ?string
     {
         return $assetProxy->getLastModified() ? $assetProxy->getLastModified()->format(DATE_W3C) : null;
     }
 
     /**
-     * @param AssetProxyInterface $assetProxy
-     * @param array $variables
-     * @param AssetSourceContext $assetSourceContext
-     * @return array<Tag>
+     * @return Tag[]
      */
     public function tags(AssetProxyInterface $assetProxy, array $variables, AssetSourceContext $assetSourceContext): array
     {
@@ -229,10 +190,7 @@ class AssetResolver implements ResolverInterface
     }
 
     /**
-     * @param AssetProxyInterface $assetProxy
-     * @param array $variables
-     * @param AssetSourceContext $assetSourceContext
-     * @return array<AssetCollection>
+     * @return AssetCollection[]
      */
     public function collections(AssetProxyInterface $assetProxy, array $variables, AssetSourceContext $assetSourceContext): array
     {
@@ -240,52 +198,26 @@ class AssetResolver implements ResolverInterface
         return $localAssetData instanceof Asset ? $localAssetData->getAssetCollections()->toArray() : [];
     }
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @return int
-     */
     public function width(AssetProxyInterface $assetProxy): int
     {
         return $assetProxy->getWidthInPixels() ?? 0;
     }
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @return int
-     */
     public function height(AssetProxyInterface $assetProxy): int
     {
         return $assetProxy->getHeightInPixels() ?? 0;
     }
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @return string
-     */
     public function thumbnailUrl(AssetProxyInterface $assetProxy): string
     {
         return (string)$assetProxy->getThumbnailUri();
     }
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @return string
-     */
     public function previewUrl(AssetProxyInterface $assetProxy): string
     {
         return (string)$assetProxy->getPreviewUri();
     }
 
-    /**
-     * @param AssetProxyInterface $assetProxy
-     * @param int $maximumWidth
-     * @param int $maximumHeight
-     * @param string $ratioMode
-     * @param bool $allowUpScaling
-     * @param bool $allowCropping
-     * @return array
-     * @throws \Exception
-     */
     public function thumbnail(
         AssetProxyInterface $assetProxy,
         int $maximumWidth,

--- a/Classes/GraphQL/Resolver/Type/AssetSourceResolver.php
+++ b/Classes/GraphQL/Resolver/Type/AssetSourceResolver.php
@@ -24,37 +24,21 @@ use t3n\GraphQL\ResolverInterface;
  */
 class AssetSourceResolver implements ResolverInterface
 {
-    /**
-     * @param AssetSourceInterface $assetSource
-     * @return string
-     */
     public function id(AssetSourceInterface $assetSource): string
     {
         return $assetSource->getIdentifier();
     }
 
-    /**
-     * @param AssetSourceInterface $assetSource
-     * @return bool
-     */
     public function supportsTagging(AssetSourceInterface $assetSource): bool
     {
         return $assetSource->getAssetProxyRepository() instanceof SupportsTaggingInterface;
     }
 
-    /**
-     * @param AssetSourceInterface $assetSource
-     * @return bool
-     */
     public function supportsCollections(AssetSourceInterface $assetSource): bool
     {
         return $assetSource->getAssetProxyRepository() instanceof SupportsCollectionsInterface;
     }
 
-    /**
-     * @param AssetSourceInterface $assetSource
-     * @return string
-     */
     public function description(AssetSourceInterface $assetSource): string
     {
         if (method_exists($assetSource, 'getDescription')) {
@@ -63,10 +47,6 @@ class AssetSourceResolver implements ResolverInterface
         return '';
     }
 
-    /**
-     * @param AssetSourceInterface $assetSource
-     * @return string
-     */
     public function iconUri(AssetSourceInterface $assetSource): string
     {
         if (method_exists($assetSource, 'getIconUri')) {

--- a/Classes/GraphQL/Resolver/Type/TagResolver.php
+++ b/Classes/GraphQL/Resolver/Type/TagResolver.php
@@ -30,10 +30,6 @@ class TagResolver implements ResolverInterface
      */
     protected $persistenceManager;
 
-    /**
-     * @param Tag $tag
-     * @return string
-     */
     public function id(Tag $tag): string
     {
         return $this->persistenceManager->getIdentifierByObject($tag);

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -2,6 +2,8 @@ privilegeTargets:
   'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
     'Flowpack.Media.Ui:ManageAssets':
       matcher: 'method(public Flowpack\Media\Ui\Controller\MediaController->(.*)Action())'
+    'Flowpack.Media.Ui:ImageApi':
+      matcher: 'method(public Flowpack\Media\Ui\Controller\ImageApiController->(.*)Action())'
     'Flowpack.Media.Ui:Queries':
       matcher: 'method(public Flowpack\Media\Ui\GraphQL\Resolver\(.*)Resolver->.*()) || method(t3n\GraphQL\Controller\GraphQLController->queryAction())'
 
@@ -15,6 +17,8 @@ roles:
       - privilegeTarget: 'Flowpack.Media.Ui:Backend.Module.Management.Media'
         permission: GRANT
       - privilegeTarget: 'Flowpack.Media.Ui:ManageAssets'
+        permission: GRANT
+      - privilegeTarget: 'Flowpack.Media.Ui:ImageApi'
         permission: GRANT
       - privilegeTarget: 'Flowpack.Media.Ui:Queries'
         permission: GRANT

--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -1,7 +1,15 @@
-- name: 'Media API'
+- name: 'Media GraphQL API'
   uriPattern: 'neos/graphql/<GraphQLSubroutes>'
   subRoutes:
     'GraphQLSubroutes':
       package: 't3n.GraphQL'
       variables:
         'endpoint': 'media-assets'
+
+- name: 'Media Async Image API'
+  uriPattern: 'neos/media-ui/{@action}/{assetSourceId}/{assetProxyId}'
+  defaults:
+    '@package': 'Flowpack.Media.Ui'
+    '@controller': 'ImageApi'
+    '@format': 'html'
+  appendExceedingArguments: true

--- a/Resources/Private/Fusion/Views/Index.fusion
+++ b/Resources/Private/Fusion/Views/Index.fusion
@@ -2,12 +2,6 @@ Flowpack.Media.Ui.MediaController {
     index = Neos.Fusion:Component {
         data-endpoints = Neos.Fusion:DataStructure {
             graphql = '/neos/graphql/media-assets'
-            upload = Neos.Fusion:UriBuilder {
-                package = 'Flowpack.Media.Ui'
-                controller = 'Upload'
-                action = 'upload'
-                format = 'json'
-            }
             @process.stringify = ${Json.stringify(value)}
         }
 

--- a/Resources/Private/JavaScript/asset-sources/typings/AssetSource.ts
+++ b/Resources/Private/JavaScript/asset-sources/typings/AssetSource.ts
@@ -1,8 +1,10 @@
 type AssetSourceType = 'AssetSource';
 
+type AssetSourceId = string;
+
 interface AssetSource extends GraphQlEntity {
     __typename: AssetSourceType;
-    readonly id: string;
+    readonly id: AssetSourceId;
     readonly label: string;
     readonly description: string;
     readonly iconUri: string;

--- a/Resources/Private/JavaScript/core/src/fragments/asset.ts
+++ b/Resources/Private/JavaScript/core/src/fragments/asset.ts
@@ -13,7 +13,8 @@ export const ASSET_FRAGMENT = gql`
         id
         localId
         assetSource {
-            ...AssetSourceProps
+            id
+            readOnly
         }
         imported
         label
@@ -40,7 +41,6 @@ export const ASSET_FRAGMENT = gql`
         previewUrl
         isInUse @include(if: $includeUsage)
     }
-    ${ASSET_SOURCE_FRAGMENT}
     ${IPTC_PROPERTY_FRAGMENT}
     ${FILE_FRAGMENT}
     ${TAG_FRAGMENT}

--- a/Resources/Private/JavaScript/core/typings/Asset.ts
+++ b/Resources/Private/JavaScript/core/typings/Asset.ts
@@ -4,7 +4,10 @@ interface Asset extends GraphQlEntity {
     __typename: AssetEntityType;
     readonly id: string;
     readonly localId?: string;
-    assetSource: AssetSource;
+    readonly assetSource: {
+        readonly id: AssetSourceId;
+        readonly readOnly: boolean;
+    };
     imported: boolean;
 
     // usage will only be queried if fast usage calculation is supported by the backend

--- a/Resources/Private/JavaScript/core/typings/global.d.ts
+++ b/Resources/Private/JavaScript/core/typings/global.d.ts
@@ -46,5 +46,9 @@ type PaginationConfig = {
     maximumLinks: number;
 };
 
+type Endpoints = {
+    graphql: string;
+};
+
 type AssetType = 'image' | 'video' | 'audio' | 'document' | 'all';
 type MediaType = `${string}/${string}`;

--- a/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/PropertyInspector.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/PropertyInspector.tsx
@@ -15,9 +15,11 @@ import InspectorContainer from './InspectorContainer';
 import Tasks from './Tasks';
 
 import classes from './PropertyInspector.module.css';
+import { useAssetSourcesQuery } from '@media-ui/feature-asset-sources';
 
 const PropertyInspector = () => {
     const selectedAsset = useSelectedAsset();
+    const { assetSources } = useAssetSourcesQuery();
     const Notify = useNotify();
     const { translate } = useIntl();
     const {
@@ -39,6 +41,8 @@ const PropertyInspector = () => {
         (label !== selectedAsset.label ||
             caption !== selectedAsset.caption ||
             copyrightNotice !== selectedAsset.copyrightNotice);
+
+    const assetSourceForSelectedAsset = assetSources.find(({ id }) => id === selectedAsset.assetSource.id);
 
     const handleDiscard = useCallback(() => {
         if (selectedAsset) {
@@ -138,8 +142,8 @@ const PropertyInspector = () => {
                 </ToggablePanel.Contents>
             </ToggablePanel>
 
-            {selectedAsset.assetSource.supportsCollections && <CollectionSelectBox />}
-            {selectedAsset.assetSource.supportsTagging && <TagSelectBoxAsset />}
+            {assetSourceForSelectedAsset.supportsCollections && <CollectionSelectBox />}
+            {assetSourceForSelectedAsset.supportsTagging && <TagSelectBoxAsset />}
 
             <Tasks />
             <MetadataView />

--- a/Resources/Private/JavaScript/media-module/src/index.tsx
+++ b/Resources/Private/JavaScript/media-module/src/index.tsx
@@ -28,7 +28,7 @@ window.onload = async (): Promise<void> => {
 
     const root = document.getElementById('media-ui-app');
     const { dummyImage } = root.dataset;
-    const endpoints = JSON.parse(root.dataset.endpoints);
+    const endpoints = JSON.parse(root.dataset.endpoints) as Endpoints;
     const featureFlags: FeatureFlags = JSON.parse(root.dataset.features);
 
     // Modal for the lightbox


### PR DESCRIPTION
The thumbnail and preview urls are now built as async Uris, to generate them very quickly and not require loading the resources during the generation of the asset list.

This and some other optimisations in this change make the `Assets` query at least 50% faster in my test cases.

- [x] Create async Uris for thumbnails and previews
- [x] Only load necessary data for each assets asset source
- [x] Optimise caching behaviour to prevent the browser from loading the same images again
- [x] Further tests and checks of UX and API 