### PR TITLE
BUGFIX: Details view shows broken or incorrect inspector

### DIFF
--- a/Resources/Private/JavaScript/core/src/components/MediaApplicationWrapper.tsx
+++ b/Resources/Private/JavaScript/core/src/components/MediaApplicationWrapper.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { MutableSnapshot, RecoilRoot } from 'recoil';
+import { ApolloClient, ApolloProvider } from '@apollo/client';
+import { NormalizedCacheObject } from '@apollo/client/cache/inmemory/types';
+
+import { InteractionProvider, IntlProvider, NotifyProvider } from '../provider';
+import {
+    applicationContextState,
+    constraintsState,
+    featureFlagsState,
+    selectedAssetIdState,
+    selectedAssetTypeState,
+    selectedInspectorViewState,
+    selectedMediaTypeState,
+} from '@media-ui/core/src/state';
+
+interface InitialStateProps {
+    applicationContext: ApplicationContext;
+    featureFlags: FeatureFlags;
+    selectedAsset?: AssetIdentity;
+    selectedInspectorView?: InspectorViewMode;
+    assetType: AssetType;
+    constraints?: SelectionConstraints;
+}
+
+interface MediaApplicationWrapperProps {
+    children: React.ReactNode;
+    client: ApolloClient<NormalizedCacheObject>;
+    translate: TranslateFunction;
+    notificationApi: NeosNotification;
+    initialState: InitialStateProps;
+}
+
+/**
+ * This component adds the necessary providers and state initialization for the Media UI.
+ */
+const MediaApplicationWrapper: React.FC<MediaApplicationWrapperProps> = ({
+    children,
+    client,
+    translate,
+    notificationApi,
+    initialState,
+}) => {
+    const initializeState = ({ set }: MutableSnapshot) => {
+        const { applicationContext, featureFlags, constraints, selectedInspectorView, selectedAsset, assetType } =
+            initialState;
+
+        set(applicationContextState, applicationContext);
+        set(featureFlagsState, featureFlags);
+
+        if (selectedAsset) {
+            set(selectedAssetIdState, selectedAsset);
+        }
+
+        if (selectedInspectorView) {
+            set(selectedInspectorViewState, selectedInspectorView);
+        }
+
+        if (assetType !== 'all') {
+            set(selectedAssetTypeState, assetType);
+        }
+
+        set(constraintsState, constraints);
+        if (constraints.mediaTypes?.length > 0) {
+            // Reset mediatype selection to prevent an empty screen with no matching assets or an invalid state
+            // FIXME: The previous state could be valid, but this would require a more complex check with the given constraints
+            set(selectedMediaTypeState, null);
+        }
+    };
+
+    return (
+        <IntlProvider translate={translate}>
+            <NotifyProvider notificationApi={notificationApi}>
+                <InteractionProvider>
+                    <ApolloProvider client={client}>
+                        <RecoilRoot initializeState={initializeState}>{children}</RecoilRoot>
+                    </ApolloProvider>
+                </InteractionProvider>
+            </NotifyProvider>
+        </IntlProvider>
+    );
+};
+
+export default MediaApplicationWrapper;

--- a/Resources/Private/JavaScript/core/src/provider/Intl.tsx
+++ b/Resources/Private/JavaScript/core/src/provider/Intl.tsx
@@ -3,23 +3,11 @@ import { createContext, useContext } from 'react';
 
 interface ProviderProps extends I18nRegistry {
     children: React.ReactElement;
-    translate: (
-        id?: string,
-        fallback?: string,
-        params?: Record<string, unknown> | string[],
-        packageKey?: string,
-        sourceName?: string
-    ) => string;
+    translate: TranslateFunction;
 }
 
 interface ProviderValues extends I18nRegistry {
-    translate: (
-        id?: string,
-        fallback?: string,
-        params?: Record<string, unknown> | string[],
-        packageKey?: string,
-        sourceName?: string
-    ) => string;
+    translate: TranslateFunction;
 }
 
 export const IntlContext = createContext(null);

--- a/Resources/Private/JavaScript/core/src/state/applicationContextState.ts
+++ b/Resources/Private/JavaScript/core/src/state/applicationContextState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const applicationContextState = atom<ApplicationContext>({
+    key: 'applicationContext',
+    default: 'browser',
+});

--- a/Resources/Private/JavaScript/core/src/state/index.ts
+++ b/Resources/Private/JavaScript/core/src/state/index.ts
@@ -12,3 +12,4 @@ export { selectedInspectorViewState } from './selectedInspectorViewState';
 export { selectedMediaTypeState } from './selectedMediaTypeState';
 export { selectedAssetTypeState } from './selectedAssetTypeState';
 export { selectedSortOrderState } from './selectedSortOrderState';
+export { applicationContextState } from './applicationContextState';

--- a/Resources/Private/JavaScript/core/src/state/localStorageEffect.ts
+++ b/Resources/Private/JavaScript/core/src/state/localStorageEffect.ts
@@ -1,12 +1,25 @@
 /**
  * This is a custom recoil storage effect that allows us to persist state in local storage.
  * It can be added to any atom as effect.
+ *
+ * If the context parameter is supplied custom behaviour is used to prevent reading and/or writing the state
+ * as only the 'browser' context should have complete control over state.
+ *
+ * TODO: Refactor the context to be more explicit about what is allowed and what is not
  */
 const STORAGE_PREFIX = 'flowpack.mediaui';
 
 // TODO: Listen to storage events to allow syncing two tabs
-export function localStorageEffect<T = any>(key: string, validate?: (value: T | undefined) => T) {
+export function localStorageEffect<T = any>(
+    key: string,
+    validate?: (value: T | undefined) => T,
+    context?: ApplicationContext
+) {
     return ({ setSelf, onSet }) => {
+        // Don't read or write the state in details screen
+        if (context == 'details') {
+            return;
+        }
         const fullKey = `${STORAGE_PREFIX}.${key}`;
         const savedValueJSON = localStorage.getItem(fullKey);
         if (savedValueJSON != null) {
@@ -17,6 +30,10 @@ export function localStorageEffect<T = any>(key: string, validate?: (value: T | 
             setSelf(savedValue);
         }
         onSet((newValue, previousValue: T | undefined, isReset) => {
+            // Don't write the state in selection screen
+            if (context == 'selection') {
+                return;
+            }
             isReset ? localStorage.removeItem(fullKey) : localStorage.setItem(fullKey, JSON.stringify(newValue));
         });
     };

--- a/Resources/Private/JavaScript/core/src/state/selectedAssetIdState.ts
+++ b/Resources/Private/JavaScript/core/src/state/selectedAssetIdState.ts
@@ -1,9 +1,19 @@
-import { atom } from 'recoil';
+import { atomFamily, selector } from 'recoil';
 
 import { localStorageEffect } from './localStorageEffect';
+import { applicationContextState } from './applicationContextState';
 
-export const selectedAssetIdState = atom<AssetIdentity>({
-    key: 'selectedAssetIdState',
+const selectedAssetIdForContextState = atomFamily<AssetIdentity, ApplicationContext>({
+    key: 'selectedAssetIdForContextState',
     default: null,
-    effects: [localStorageEffect('selectedAssetIdState')],
+    effects: (applicationContext) => [
+        localStorageEffect('selectedAssetIdForContextState', undefined, applicationContext),
+    ],
+});
+
+export const selectedAssetIdState = selector<AssetIdentity>({
+    key: 'selectedAssetIdState',
+    get: ({ get }) => get(selectedAssetIdForContextState(get(applicationContextState))),
+    set: ({ get, set }, assetIdentity) =>
+        set(selectedAssetIdForContextState(get(applicationContextState)), assetIdentity),
 });

--- a/Resources/Private/JavaScript/core/src/state/selectedInspectorViewState.ts
+++ b/Resources/Private/JavaScript/core/src/state/selectedInspectorViewState.ts
@@ -1,9 +1,17 @@
-import { atom } from 'recoil';
+import { atomFamily, selector } from 'recoil';
 import { localStorageEffect } from './localStorageEffect';
+import { applicationContextState } from './applicationContextState';
 
-export const selectedInspectorViewState = atom<null | 'asset' | 'assetCollection' | 'tag'>({
-    key: 'selectedInspectorViewState',
+const selectedInspectorViewForContextState = atomFamily<null | InspectorViewMode, ApplicationContext>({
+    key: 'selectedInspectorViewForContextState',
     default: null,
     // TODO: Add validator to make sure we can display the selected inspector view
-    effects: [localStorageEffect('selectedInspectorViewState')],
+    effects: (applicationContext) => [localStorageEffect('selectedInspectorViewState', undefined, applicationContext)],
+});
+
+export const selectedInspectorViewState = selector<InspectorViewMode>({
+    key: 'selectedInspectorViewState',
+    get: ({ get }) => get(selectedInspectorViewForContextState(get(applicationContextState))),
+    set: ({ get, set }, mode: InspectorViewMode) =>
+        set(selectedInspectorViewForContextState(get(applicationContextState)), mode),
 });

--- a/Resources/Private/JavaScript/core/typings/global.d.ts
+++ b/Resources/Private/JavaScript/core/typings/global.d.ts
@@ -15,15 +15,17 @@ interface NeosI18n {
     initialized: boolean;
 }
 
+type TranslateFunction = (
+    id?: string,
+    fallback?: string,
+    params?: Record<string, unknown> | (string | number)[],
+    packageKey?: string,
+    sourceName?: string
+) => string;
+
 // TODO: This is a copy of the interface in Neos.Ui and should preferably be made available to plugins
 interface I18nRegistry {
-    translate: (
-        id?: string,
-        fallback?: string,
-        params?: Record<string, unknown> | (string | number)[],
-        packageKey?: string,
-        sourceName?: string
-    ) => string;
+    translate: TranslateFunction;
 }
 
 interface NeosNotification {
@@ -48,3 +50,6 @@ type PaginationConfig = {
 
 type AssetType = 'image' | 'video' | 'audio' | 'document' | 'all';
 type MediaType = `${string}/${string}`;
+
+type ApplicationContext = 'browser' | 'details' | 'selection';
+type InspectorViewMode = 'asset' | 'assetCollection' | 'tag';

--- a/Resources/Private/JavaScript/media-details-screen/src/components/Details.tsx
+++ b/Resources/Private/JavaScript/media-details-screen/src/components/Details.tsx
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil';
 import cx from 'classnames';
 
 import { InteractionDialogRenderer, useMediaUi } from '@media-ui/core';
-import { useSelectAsset, useAssetQuery } from '@media-ui/core/src/hooks';
+import { useAssetQuery } from '@media-ui/core/src/hooks';
 import { AssetUsagesModal, assetUsageDetailsModalState } from '@media-ui/feature-asset-usage';
 import { ClipboardWatcher } from '@media-ui/feature-clipboard';
 import { ConcurrentChangeMonitor } from '@media-ui/feature-concurrent-editing';
@@ -23,25 +23,22 @@ import Preview from './Preview';
 
 import theme from '@media-ui/core/src/Theme.module.css';
 import classes from './Details.module.css';
+import { selectedAssetIdState } from '@media-ui/core/src/state';
 
 interface DetailsProps {
-    assetIdentity: AssetIdentity;
     buildLinkToMediaUi: (asset: Asset) => string;
 }
 
-const Details = ({ assetIdentity, buildLinkToMediaUi }: DetailsProps) => {
+const Details = ({ buildLinkToMediaUi }: DetailsProps) => {
     const { containerRef } = useMediaUi();
     const { visible: showUploadDialog } = useRecoilValue(uploadDialogState);
     const { visible: showCreateTagDialog } = useRecoilValue(createTagDialogState);
     const showCreateAssetCollectionDialog = useRecoilValue(createAssetCollectionDialogVisibleState);
     const showAssetUsagesModal = useRecoilValue(assetUsageDetailsModalState);
     const showSimilarAssetsModal = useRecoilValue(similarAssetsModalState);
-    const selectAsset = useSelectAsset();
-    const { asset, loading } = useAssetQuery(assetIdentity);
-
-    React.useEffect(() => {
-        selectAsset(assetIdentity);
-    }, [assetIdentity, selectAsset]);
+    const selectedAssetId = useRecoilValue(selectedAssetIdState);
+    // FIXME: Adjust useSelectedAssetHook and use its loading state
+    const { asset, loading } = useAssetQuery(selectedAssetId);
 
     return (
         <div className={cx(classes.container, theme.mediaModuleTheme, loading && classes.loading)} ref={containerRef}>

--- a/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/AssetInspector.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/AssetInspector.tsx
@@ -3,8 +3,7 @@ import { useRecoilValue } from 'recoil';
 
 import { Tabs } from '@neos-project/react-ui-components';
 
-import { useSelectedAsset } from '@media-ui/core/src/hooks';
-import { featureFlagsState, selectedInspectorViewState } from '@media-ui/core/src/state';
+import { featureFlagsState, selectedAssetIdState, selectedInspectorViewState } from '@media-ui/core/src/state';
 import VariantsInspector from '@media-ui/feature-asset-variants/src/components/VariantsInspector';
 
 import PropertyInspector from './PropertyInspector';
@@ -12,11 +11,11 @@ import PropertyInspector from './PropertyInspector';
 import classes from './AssetInspector.module.css';
 
 const AssetInspector = () => {
-    const selectedAsset = useSelectedAsset();
+    const selectedAssetId = useRecoilValue(selectedAssetIdState);
     const { showVariantsEditor } = useRecoilValue(featureFlagsState);
     const selectedInspectorView = useRecoilValue(selectedInspectorViewState);
 
-    if (!selectedAsset || selectedInspectorView !== 'asset') return null;
+    if (!selectedAssetId || selectedInspectorView !== 'asset') return null;
 
     return showVariantsEditor ? (
         <Tabs theme={{ tabs__content: classes.tabContent }}>

--- a/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/Tasks.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/Tasks.tsx
@@ -3,21 +3,21 @@ import { useRecoilValue } from 'recoil';
 
 import { Headline } from '@neos-project/react-ui-components';
 
-import { useIntl, useMediaUi } from '@media-ui/core';
+import { useIntl } from '@media-ui/core';
 import { IconLabel } from '@media-ui/core/src/components';
 import { AssetUsagesToggleButton } from '@media-ui/feature-asset-usage/src/index';
 import { SimilarAssetsToggleButton } from '@media-ui/feature-similar-assets';
 import { AssetReplacementButton } from '@media-ui/feature-asset-upload/src/components';
 import { OpenAssetEditDialogButton } from '@media-ui/feature-asset-editing';
 import { useSelectedAsset } from '@media-ui/core/src/hooks';
-import { featureFlagsState } from '@media-ui/core/src/state';
+import { applicationContextState, featureFlagsState } from '@media-ui/core/src/state';
 
 import classes from './Tasks.module.css';
 
 const Tasks: React.FC = () => {
     const { translate } = useIntl();
     const selectedAsset = useSelectedAsset();
-    const { isInMediaDetailsScreen } = useMediaUi();
+    const applicationContext = useRecoilValue(applicationContextState);
     const { showSimilarAssets } = useRecoilValue(featureFlagsState);
 
     if (!selectedAsset) return null;
@@ -29,8 +29,8 @@ const Tasks: React.FC = () => {
             </Headline>
             <AssetUsagesToggleButton />
             {showSimilarAssets && <SimilarAssetsToggleButton />}
-            {!selectedAsset.assetSource.readOnly && !isInMediaDetailsScreen && <AssetReplacementButton />}
-            {!selectedAsset.assetSource.readOnly && !isInMediaDetailsScreen && <OpenAssetEditDialogButton />}
+            {!selectedAsset.assetSource.readOnly && applicationContext !== 'details' && <AssetReplacementButton />}
+            {!selectedAsset.assetSource.readOnly && applicationContext !== 'details' && <OpenAssetEditDialogButton />}
         </div>
     );
 };

--- a/Resources/Private/JavaScript/media-module/src/components/TopBar/AssetsFilter/AssetTypeFilter.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/TopBar/AssetsFilter/AssetTypeFilter.tsx
@@ -3,7 +3,7 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { SelectBox } from '@neos-project/react-ui-components';
 
-import { useIntl, useMediaUi } from '@media-ui/core';
+import { useIntl } from '@media-ui/core';
 import {
     currentPageState,
     featureFlagsState,
@@ -11,6 +11,7 @@ import {
     selectedMediaTypeState,
 } from '@media-ui/core/src/state';
 import { showUnusedAssetsState } from '@media-ui/feature-asset-usage';
+import classes from './AssetsFilter.module.css';
 
 const UNUSED_FILTER_VALUE = 'unused';
 
@@ -22,10 +23,8 @@ interface AssetTypeOptions {
     };
 }
 
-import classes from './AssetsFilter.module.css';
-
 const AssetTypeFilter: React.FC = () => {
-    const { assetType } = useMediaUi();
+    const assetType = useRecoilValue(selectedAssetTypeState);
     const featureFlags = useRecoilValue(featureFlagsState);
     const [assetTypeFilter, setAssetTypeFilter] = useRecoilState(selectedAssetTypeState);
     const setMediaTypeFilter = useSetRecoilState(selectedMediaTypeState);

--- a/Resources/Private/JavaScript/media-module/src/index.tsx
+++ b/Resources/Private/JavaScript/media-module/src/index.tsx
@@ -1,20 +1,18 @@
 import React, { createRef } from 'react';
 import { render } from 'react-dom';
 import Modal from 'react-modal';
-import { RecoilRoot } from 'recoil';
 import { DndProvider } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-import { ApolloClient, ApolloLink, ApolloProvider } from '@apollo/client';
+import { ApolloClient, ApolloLink } from '@apollo/client';
 import { createUploadLink } from 'apollo-upload-client';
 
-import { InteractionProvider, IntlProvider, MediaUiProvider, NotifyProvider } from '@media-ui/core';
-
 // GraphQL type definitions
-import { typeDefs as TYPE_DEFS_CORE } from '@media-ui/core';
+import { MediaUiProvider, typeDefs as TYPE_DEFS_CORE } from '@media-ui/core';
+import MediaApplicationWrapper from '@media-ui/core/src/components/MediaApplicationWrapper';
 import { typeDefs as TYPE_DEFS_ASSET_USAGE } from '@media-ui/feature-asset-usage';
 
 // Internal dependencies
-import { createErrorHandler, CacheFactory } from './core';
+import { CacheFactory, createErrorHandler } from './core';
 import App from './components/App';
 import ErrorBoundary from './components/ErrorBoundary';
 import loadIconLibrary from './lib/FontAwesome';
@@ -58,28 +56,28 @@ window.onload = async (): Promise<void> => {
         typeDefs: [TYPE_DEFS_CORE, TYPE_DEFS_ASSET_USAGE],
     });
 
+    const initialState = {
+        applicationContext: 'browser' as ApplicationContext,
+        featureFlags,
+        constraints: {},
+        assetType: 'all' as AssetType,
+    };
+
     render(
-        <IntlProvider translate={translate}>
-            <NotifyProvider notificationApi={Notification}>
-                <InteractionProvider>
-                    <ApolloProvider client={client}>
-                        <RecoilRoot>
-                            <ErrorBoundary>
-                                <MediaUiProvider
-                                    dummyImage={dummyImage}
-                                    containerRef={containerRef}
-                                    featureFlags={featureFlags}
-                                >
-                                    <DndProvider backend={HTML5Backend}>
-                                        <App />
-                                    </DndProvider>
-                                </MediaUiProvider>
-                            </ErrorBoundary>
-                        </RecoilRoot>
-                    </ApolloProvider>
-                </InteractionProvider>
-            </NotifyProvider>
-        </IntlProvider>,
+        <MediaApplicationWrapper
+            client={client}
+            translate={translate}
+            notificationApi={Notification}
+            initialState={initialState}
+        >
+            <ErrorBoundary>
+                <MediaUiProvider dummyImage={dummyImage} containerRef={containerRef}>
+                    <DndProvider backend={HTML5Backend}>
+                        <App />
+                    </DndProvider>
+                </MediaUiProvider>
+            </ErrorBoundary>
+        </MediaApplicationWrapper>,
         root
     );
 };


### PR DESCRIPTION
Separate selection context between application states to make the details and partially the selection view independent of the browser.

The initial state is now applied to the RecoilRoot via the MediaApplicationWrapper which also cleans up the code of the 3 application variants.