### PR TITLE
TASK: change button style of AssetAction buttons too neutral

### DIFF
--- a/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
@@ -68,7 +68,7 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
                 title={translate('itemActions.preview', 'Preview asset')}
                 icon="expand-alt"
                 size="regular"
-                style="transparent"
+                style="neutral"
                 hoverStyle="brand"
                 onClick={() => setSelectedAssetForPreview({ assetId: asset.id, assetSourceId: asset.assetSource.id })}
             />
@@ -77,7 +77,7 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
                     title={translate('itemActions.import', 'Import asset')}
                     icon="cloud-download-alt"
                     size="regular"
-                    style="transparent"
+                    style="neutral"
                     hoverStyle="brand"
                     onClick={onImportAsset}
                 />
@@ -92,14 +92,14 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
                     disabled={asset.isInUse}
                     icon="trash"
                     size="regular"
-                    style="transparent"
+                    style="neutral"
                     hoverStyle="error"
                     onClick={() => onDeleteAsset(asset)}
                 />
             )}
             {asset.file?.url && (
                 <a href={asset.file.url} download title={translate('itemActions.download', 'Download asset')}>
-                    <IconButton icon="download" size="regular" style="transparent" hoverStyle="success" />
+                    <IconButton icon="download" size="regular" style="neutral" hoverStyle="success" />
                 </a>
             )}
             {asset.localId && (
@@ -107,7 +107,7 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
                     title={translate('itemActions.copyToClipboard', 'Copy to clipboard')}
                     icon={isInClipboard ? 'clipboard-check' : 'clipboard'}
                     size="regular"
-                    style="transparent"
+                    style="neutral"
                     hoverStyle="brand"
                     className={isInClipboard ? 'button--active' : ''}
                     onClick={toggleClipboardState}

--- a/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
@@ -104,9 +104,7 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
                     <IconButton
                         icon="download"
                         size="regular"
-                        style={viewModeSelection === VIEW_MODES.List
-                            ? 'transparent'
-                            : 'neutral'}
+                        style={viewModeSelection === VIEW_MODES.List ? 'transparent' : 'neutral'}
                         hoverStyle="success"
                     />
                 </a>

--- a/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useSetRecoilState, useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { IconButton } from '@neos-project/react-ui-components';
 
@@ -7,6 +7,7 @@ import { useIntl, useMediaUi, useNotify } from '@media-ui/core';
 import { useDeleteAsset, useImportAsset } from '@media-ui/core/src/hooks';
 import { selectedAssetForPreviewState } from '@media-ui/feature-asset-preview';
 import { clipboardItemState } from '@media-ui/feature-clipboard';
+import { VIEW_MODES, viewModeState } from '../../state';
 
 interface ItemActionsProps {
     asset: Asset;
@@ -22,6 +23,7 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
     const [isInClipboard, toggleClipboardState] = useRecoilState(
         clipboardItemState({ assetId: asset.id, assetSourceId: asset.assetSource.id })
     );
+    const [viewModeSelection, setViewModeSelection] = useRecoilState(viewModeState);
 
     // TODO: Optimize rendering this component when hooks change, as it takes quite a bit of time
     const onImportAsset = useCallback(() => {
@@ -68,7 +70,7 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
                 title={translate('itemActions.preview', 'Preview asset')}
                 icon="expand-alt"
                 size="regular"
-                style="neutral"
+                style={viewModeSelection === VIEW_MODES.List ? 'transparent' : 'neutral'}
                 hoverStyle="brand"
                 onClick={() => setSelectedAssetForPreview({ assetId: asset.id, assetSourceId: asset.assetSource.id })}
             />
@@ -77,7 +79,7 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
                     title={translate('itemActions.import', 'Import asset')}
                     icon="cloud-download-alt"
                     size="regular"
-                    style="neutral"
+                    style={viewModeSelection === VIEW_MODES.List ? 'transparent' : 'neutral'}
                     hoverStyle="brand"
                     onClick={onImportAsset}
                 />
@@ -92,14 +94,21 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
                     disabled={asset.isInUse}
                     icon="trash"
                     size="regular"
-                    style="neutral"
+                    style={viewModeSelection === VIEW_MODES.List ? 'transparent' : 'neutral'}
                     hoverStyle="error"
                     onClick={() => onDeleteAsset(asset)}
                 />
             )}
             {asset.file?.url && (
                 <a href={asset.file.url} download title={translate('itemActions.download', 'Download asset')}>
-                    <IconButton icon="download" size="regular" style="neutral" hoverStyle="success" />
+                    <IconButton
+                        icon="download"
+                        size="regular"
+                        style={viewModeSelection === VIEW_MODES.List
+                            ? 'transparent'
+                            : 'neutral'}
+                        hoverStyle="success"
+                    />
                 </a>
             )}
             {asset.localId && (
@@ -107,7 +116,7 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
                     title={translate('itemActions.copyToClipboard', 'Copy to clipboard')}
                     icon={isInClipboard ? 'clipboard-check' : 'clipboard'}
                     size="regular"
-                    style="neutral"
+                    style={viewModeSelection === VIEW_MODES.List ? 'transparent' : 'neutral'}
                     hoverStyle="brand"
                     className={isInClipboard ? 'button--active' : ''}
                     onClick={toggleClipboardState}

--- a/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
@@ -23,7 +23,7 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
     const [isInClipboard, toggleClipboardState] = useRecoilState(
         clipboardItemState({ assetId: asset.id, assetSourceId: asset.assetSource.id })
     );
-    const [viewModeSelection, setViewModeSelection] = useRecoilState(viewModeState);
+    const [viewModeSelection] = useRecoilState(viewModeState);
 
     // TODO: Optimize rendering this component when hooks change, as it takes quite a bit of time
     const onImportAsset = useCallback(() => {


### PR DESCRIPTION
resolves: #198 

**What I did**

See: https://github.com/Flowpack/media-ui/issues/198

If the buttons are transparent it makes them a bit hard to see especially if you have a file with a white background, for example. And since the icons themselves already have a white color, it doesent look very nice on a transparent background.

Besides, it simply makes a nicer impression in general in my opinion.
But I am of course open for opinions !

**How I did it**

Changed the style of the AssetActions buttons from transparent too neutral.

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->

### Before

![SCR-20230804-ssyq](https://github.com/Flowpack/media-ui/assets/39345336/18adaaff-4095-4bb1-b339-82bff8ef08f1)

### After
![SCR-20230804-srrh](https://github.com/Flowpack/media-ui/assets/39345336/23afe3c1-9886-4ccf-9806-71406436514e)
