### PR TITLE
TASK: change hover style of cancel button to error in CreateAssetCollectionDialog

### DIFF
--- a/Resources/Private/JavaScript/asset-collections/src/components/CreateAssetCollectionDialog.tsx
+++ b/Resources/Private/JavaScript/asset-collections/src/components/CreateAssetCollectionDialog.tsx
@@ -47,7 +47,7 @@ const CreateAssetCollectionDialog = () => {
             })}
             onRequestClose={handleRequestClose}
             actions={[
-                <Button key="cancel" style="neutral" hoverStyle="darken" onClick={handleRequestClose}>
+                <Button key="cancel" style="neutral" hoverStyle="error" onClick={handleRequestClose}>
                     {translate('general.cancel', 'Cancel')}
                 </Button>,
                 <Button key="upload" style="success" hoverStyle="success" disabled={!title} onClick={handleCreate}>


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

I change the hover style of the cancel button in the CreateAssetCollectionDialog to `error`. Because its standard in Neos for Discard/Cancel Buttons that they are red. At least, I have not seen anything else yet.

**How I did it**

Adjusted the `CreateAssetCollectionDialog.tsx` component.

**How to verify it**

![after](https://github.com/Flowpack/media-ui/assets/39345336/ff96198c-ba51-4ebb-9aa7-50f63d31d877)
