### PR TITLE
TASK: Add few improvments to CreateTagDialog

### DIFF
--- a/Resources/Private/JavaScript/asset-tags/src/components/CreateTagDialog.tsx
+++ b/Resources/Private/JavaScript/asset-tags/src/components/CreateTagDialog.tsx
@@ -40,7 +40,7 @@ const CreateTagDialog: React.FC = () => {
             title={translate('createTagDialog.title', 'Create tag')}
             onRequestClose={handleRequestClose}
             actions={[
-                <Button key="cancel" style="neutral" hoverStyle="darken" onClick={handleRequestClose}>
+                <Button key="cancel" style="neutral" hoverStyle="error" onClick={handleRequestClose}>
                     {translate('general.cancel', 'Cancel')}
                 </Button>,
                 <Button
@@ -55,7 +55,7 @@ const CreateTagDialog: React.FC = () => {
             ]}
         >
             <div className={classes.formBody}>
-                <Label>{translate('general.label', 'Label')}</Label>
+                <Label>{translate('general.label', 'Title')}</Label>
                 <TextInput
                     setFocus
                     type="text"


### PR DESCRIPTION
**What I did**

I added some small adjustmens to the CreateTagDialog

1. First, i changed the hover style of the cancel button to error like i already did it in #200 
2. I changed the label in the create dialog to: `Title` like in the CreateAssetCollectionDialog to keep it consistent. And tbh i see no difference between the word `Label` and `Title`. But `Title` sounds better IMO.

**How I did it**

I adjusted the `CreateTagDialog.tsx` component.

**How to verify it**
![tag-dialog](https://github.com/Flowpack/media-ui/assets/39345336/b0913160-3867-4ec0-993c-6cf22ec69c83)


<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
