### PR TITLE
FEATURE: Render asset usage counter inside inspector action buttons

### DIFF
--- a/Resources/Private/JavaScript/asset-usage/src/components/AssetUsageSection.module.css
+++ b/Resources/Private/JavaScript/asset-usage/src/components/AssetUsageSection.module.css
@@ -9,6 +9,8 @@
     width: 100%;
     margin-top: var(--theme-spacing-Full);
     line-height: 1.5;
+    border-collapse: separate;
+    border-spacing: 0;
 }
 
 .usageTable th {
@@ -18,17 +20,13 @@
 
 .usageTable td,
 .usageTable th {
-    padding: var(--theme-spacing-Quarter);
+    padding: 0 var(--theme-spacing-Half);
+    height: var(--theme-unit);
 }
 
-.usageTable td:first-child,
-.usageTable th:first-child {
-    padding-left: 0;
-}
-
-.usageTable td:last-child,
-.usageTable th:last-child {
-    padding-right: 0;
+.usageTable td {
+    border-top: 1px solid var(--theme-colors-ContrastDarker);
+    background-color: var(--theme-colors-ContrastNeutral);
 }
 
 /* This is for specificity; otherwise `.neos.neos-module a` would override this link style in the backend module */

--- a/Resources/Private/JavaScript/asset-usage/src/components/AssetUsagesToggleButton.module.css
+++ b/Resources/Private/JavaScript/asset-usage/src/components/AssetUsagesToggleButton.module.css
@@ -1,0 +1,3 @@
+.assetUsageBadge {
+    color: var(--theme-blue);
+}

--- a/Resources/Private/JavaScript/asset-usage/src/components/AssetUsagesToggleButton.tsx
+++ b/Resources/Private/JavaScript/asset-usage/src/components/AssetUsagesToggleButton.tsx
@@ -1,21 +1,27 @@
 import React from 'react';
 import { useRecoilState } from 'recoil';
 
-import { Button, Icon } from '@neos-project/react-ui-components';
+import { Badge, Button, Icon } from '@neos-project/react-ui-components';
 
 import { useIntl } from '@media-ui/core';
 import { useSelectedAsset } from '@media-ui/core/src/hooks';
 
 import assetUsageDetailsModalState from '../state/assetUsageDetailsModalState';
+import useAssetUsagesQuery from '@media-ui/feature-asset-usage/src/hooks/useAssetUsages';
+
+import classes from './AssetUsagesToggleButton.module.css';
 
 const AssetUsagesToggleButton: React.FC = () => {
-    const { isInUse } = useSelectedAsset();
+    const asset = useSelectedAsset();
+    const { assetUsageDetails, loading } = useAssetUsagesQuery(
+        asset ? { assetId: asset.id, assetSourceId: asset.assetSource.id } : null
+    );
     const [assetUsagesModalOpen, setAssetUsagesModalOpen] = useRecoilState(assetUsageDetailsModalState);
     const { translate } = useIntl();
 
     return (
         <Button
-            disabled={isInUse === false}
+            disabled={asset.isInUse === false}
             size="regular"
             style={assetUsagesModalOpen ? 'brand' : 'lighter'}
             hoverStyle="brand"
@@ -23,6 +29,11 @@ const AssetUsagesToggleButton: React.FC = () => {
         >
             <Icon icon="link" />
             {translate('assetUsageList.toggle', 'Show usages')}
+            {assetUsageDetails?.[0]?.usages ? (
+                <Badge label={assetUsageDetails[0].usages.length} className={classes.assetUsageBadge} />
+            ) : (
+                <></>
+            )}
         </Button>
     );
 };


### PR DESCRIPTION
**What I did**

- i have extended `AssetUsageToggleButton` component to show also asset udage counter
- i have modified `AssetUsageSection` styles so the table rendered inside dialog window looks a bit better

**How I did it**
- i have modified `AssetUsageToggleButton` and `AssetUsageSection` components
- i have modified CSS

**How to verify it**

- go to Media module
- select some asset with or without usages
- for asset with usages set, you should see badge with number on the `Show usgaes` button inside inspector actions/tasks
- if you open dialog with usages, you should see re-styled table with usage items

**If asset has no usages**

![image](https://github.com/Flowpack/media-ui/assets/1798417/071e23fc-8be1-45b1-be3c-fdb7c7b8c93c)

**If asset has usages**

![image](https://github.com/Flowpack/media-ui/assets/1798417/e9c7ac17-ed9e-41e6-8f61-59aebaa75828)

**Table inside modal with asset usages**

before

![image](https://github.com/Flowpack/media-ui/assets/1798417/2e82389b-4ac6-4abb-8de3-a605651a95d4)

after

![image](https://github.com/Flowpack/media-ui/assets/1798417/3a4e65ab-a677-466b-82d2-bbcdd3f4033c)
