### PR TITLE
FEATURE: Implement privilege for hierarchical asset collections

### DIFF
--- a/Classes/Aspect/HierarchicalAssetCollectionAspect.php
+++ b/Classes/Aspect/HierarchicalAssetCollectionAspect.php
@@ -45,8 +45,7 @@ class HierarchicalAssetCollectionAspect
 
     /**
      * @var string
-     * @ORM\Column(length=1000)
-     * @ORM\Column(nullable=true)
+     * @ORM\Column(length=1000,nullable=true)
      * @Flow\Introduce("class(Neos\Media\Domain\Model\AssetCollection)")
      */
     protected $path = null;
@@ -105,6 +104,18 @@ class HierarchicalAssetCollectionAspect
     }
 
     /**
+     * @Flow\Around("method(Neos\Media\Domain\Model\AssetCollection->__construct())")
+     */
+    public function updatePathAfterConstruct(JoinPointInterface $joinPoint): void
+    {
+        $joinPoint->getAdviceChain()->proceed($joinPoint);
+
+        /** @var HierarchicalAssetCollectionInterface $assetCollection */
+        $assetCollection = $joinPoint->getProxy();
+        $assetCollection->setPath(AssetCollectionUtility::renderValidPath($assetCollection));
+    }
+
+    /**
      * @Flow\Around("method(Neos\Media\Domain\Model\AssetCollection->hasParent())")
      */
     public function hasParent(JoinPointInterface $joinPoint): bool
@@ -122,6 +133,18 @@ class HierarchicalAssetCollectionAspect
         /** @var AssetCollection $assetCollection */
         $assetCollection = $joinPoint->getProxy();
         return $assetCollection->getTitle();
+    }
+
+    /**
+     * @Flow\Around("method(Neos\Media\Domain\Model\AssetCollection->setTitle())")
+     */
+    public function setTitle(JoinPointInterface $joinPoint): void
+    {
+        $joinPoint->getAdviceChain()->proceed($joinPoint);
+
+        /** @var HierarchicalAssetCollectionInterface $assetCollection */
+        $assetCollection = $joinPoint->getProxy();
+        $assetCollection->setPath(AssetCollectionUtility::renderValidPath($assetCollection));
     }
 
     /**

--- a/Classes/Domain/Model/HierarchicalAssetCollectionInterface.php
+++ b/Classes/Domain/Model/HierarchicalAssetCollectionInterface.php
@@ -54,4 +54,14 @@ interface HierarchicalAssetCollectionInterface
      * @return bool
      */
     public function hasParent();
+
+    /**
+     * @return string|null
+     */
+    public function getPath();
+
+    /**
+     * @return void
+     */
+    public function setPath(?string $path);
 }

--- a/Classes/GraphQL/Resolver/Type/MutationResolver.php
+++ b/Classes/GraphQL/Resolver/Type/MutationResolver.php
@@ -22,17 +22,15 @@ use Flowpack\Media\Ui\Domain\Model\HierarchicalAssetCollectionInterface;
 use Flowpack\Media\Ui\Exception;
 use Flowpack\Media\Ui\GraphQL\Context\AssetSourceContext;
 use Flowpack\Media\Ui\Service\AssetCollectionService;
-use Flowpack\Media\Ui\Utility\AssetCollectionUtility;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\I18n\Translator;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\Exception\InvalidQueryException;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Http\Factories\FlowUploadedFile;
 use Neos\Media\Domain\Model\Asset;
-use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\AssetCollection;
+use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Media\Domain\Repository\AssetRepository;
@@ -688,8 +686,6 @@ class MutationResolver implements ResolverInterface
 
         if (is_string($title) && trim($title)) {
             $assetCollection->setTitle(trim($title));
-            /** @var HierarchicalAssetCollectionInterface $assetCollection */
-            $assetCollection->setPath(AssetCollectionUtility::renderValidPath($assetCollection));
         }
 
         if ($tagIds !== null) {

--- a/Classes/GraphQL/Resolver/Type/MutationResolver.php
+++ b/Classes/GraphQL/Resolver/Type/MutationResolver.php
@@ -21,6 +21,8 @@ use Flowpack\Media\Ui\Domain\Model\Dto\MutationResult;
 use Flowpack\Media\Ui\Domain\Model\HierarchicalAssetCollectionInterface;
 use Flowpack\Media\Ui\Exception;
 use Flowpack\Media\Ui\GraphQL\Context\AssetSourceContext;
+use Flowpack\Media\Ui\Service\AssetCollectionService;
+use Flowpack\Media\Ui\Utility\AssetCollectionUtility;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\I18n\Translator;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
@@ -106,6 +108,12 @@ class MutationResolver implements ResolverInterface
      * @var AssetService
      */
     protected $assetService;
+
+    /**
+     * @Flow\Inject
+     * @var AssetCollectionService
+     */
+    protected $assetCollectionService;
 
     /**
      * @throws Exception
@@ -680,6 +688,8 @@ class MutationResolver implements ResolverInterface
 
         if (is_string($title) && trim($title)) {
             $assetCollection->setTitle(trim($title));
+            /** @var HierarchicalAssetCollectionInterface $assetCollection */
+            $assetCollection->setPath(AssetCollectionUtility::renderValidPath($assetCollection));
         }
 
         if ($tagIds !== null) {
@@ -695,6 +705,7 @@ class MutationResolver implements ResolverInterface
         }
 
         $this->assetCollectionRepository->update($assetCollection);
+        $this->assetCollectionService->updatePathForNestedAssetCollections($assetCollection);
 
         return true;
     }
@@ -727,6 +738,7 @@ class MutationResolver implements ResolverInterface
             $assetCollection->setParent(null);
         }
         $this->assetCollectionRepository->update($assetCollection);
+        $this->assetCollectionService->updatePathForNestedAssetCollections($assetCollection);
         return true;
     }
 

--- a/Classes/Security/Authorization/Privilege/Doctrine/AssetAssetCollectionConditionGenerator.php
+++ b/Classes/Security/Authorization/Privilege/Doctrine/AssetAssetCollectionConditionGenerator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\Security\Authorization\Privilege\Doctrine;
+
+/*
+ * This file is part of the Flowpack.Media.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine\PropertyConditionGenerator;
+use Neos\Flow\Validation\Validator\UuidValidator;
+
+/**
+ * Condition generator covering Asset <-> HierarchicalAssetCollection relations
+ * (M:M relations are not supported by the Flow PropertyConditionGenerator yet)
+ */
+class AssetAssetCollectionConditionGenerator extends
+    \Neos\Media\Security\Authorization\Privilege\Doctrine\AssetAssetCollectionConditionGenerator
+{
+
+    /**
+     * @param DoctrineSqlFilter $sqlFilter
+     * @param ClassMetadata $targetEntity Metadata object for the target entity to create the constraint for
+     * @param string $targetTableAlias The target table alias used in the current query
+     * @return string
+     */
+    public function getSql(DoctrineSqlFilter $sqlFilter, ClassMetadata $targetEntity, $targetTableAlias): string
+    {
+        $propertyConditionGenerator = new PropertyConditionGenerator('');
+        $collectionTitleOrIdentifier = $propertyConditionGenerator->getValueForOperand($this->collectionTitleOrIdentifier);
+        if (preg_match(UuidValidator::PATTERN_MATCH_UUID, $collectionTitleOrIdentifier) === 1) {
+            $whereCondition = $targetTableAlias . '_ac.persistence_object_identifier = ' . $this->entityManager->getConnection()->quote($collectionTitleOrIdentifier);
+        } else {
+            $whereCondition = $targetTableAlias . '_ac.path LIKE ' . $this->entityManager->getConnection()->quote($collectionTitleOrIdentifier . '%');
+        }
+
+        return $targetTableAlias . '.persistence_object_identifier IN (
+            SELECT ' . $targetTableAlias . '_a.persistence_object_identifier
+            FROM neos_media_domain_model_asset AS ' . $targetTableAlias . '_a
+            LEFT JOIN neos_media_domain_model_assetcollection_assets_join ' . $targetTableAlias . '_acj ON ' . $targetTableAlias . '_a.persistence_object_identifier = ' . $targetTableAlias . '_acj.media_asset
+            LEFT JOIN neos_media_domain_model_assetcollection ' . $targetTableAlias . '_ac ON ' . $targetTableAlias . '_ac.persistence_object_identifier = ' . $targetTableAlias . '_acj.media_assetcollection
+            WHERE ' . $whereCondition . ')';
+    }
+}

--- a/Classes/Security/Authorization/Privilege/Doctrine/AssetConditionGenerator.php
+++ b/Classes/Security/Authorization/Privilege/Doctrine/AssetConditionGenerator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\Security\Authorization\Privilege\Doctrine;
+
+/*
+ * This file is part of the Flowpack.Media.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A SQL condition generator, supporting special SQL constraints for assets in hierarchical asset collections
+ */
+class AssetConditionGenerator extends \Neos\Media\Security\Authorization\Privilege\Doctrine\AssetConditionGenerator
+{
+    public function isInCollectionPath(string $collectionTitle): AssetAssetCollectionConditionGenerator
+    {
+        return new AssetAssetCollectionConditionGenerator($collectionTitle);
+    }
+}

--- a/Classes/Security/Authorization/Privilege/Doctrine/HierarchicalAssetCollectionConditionGenerator.php
+++ b/Classes/Security/Authorization/Privilege/Doctrine/HierarchicalAssetCollectionConditionGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\Security\Authorization\Privilege\Doctrine;
+
+/*
+ * This file is part of the Flowpack.Media.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine\PropertyConditionGenerator;
+use Neos\Media\Security\Authorization\Privilege\Doctrine\AssetCollectionConditionGenerator;
+
+/**
+ * An extended SQL condition generator, supporting special SQL constraints for hierarchical asset collections
+ */
+class HierarchicalAssetCollectionConditionGenerator extends AssetCollectionConditionGenerator
+{
+    public function isInPath(string $path): PropertyConditionGenerator
+    {
+        return (new PropertyConditionGenerator('path'))->like($path . '%');
+    }
+}

--- a/Classes/Security/Authorization/Privilege/ReadAssetPrivilege.php
+++ b/Classes/Security/Authorization/Privilege/ReadAssetPrivilege.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\Security\Authorization\Privilege;
+
+/*
+ * This file is part of the Flowpack.Media.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Flowpack\Media\Ui\Security\Authorization\Privilege\Doctrine\AssetConditionGenerator;
+
+/**
+ * Privilege for restricting reading of Assets in hierarchical asset collections
+ */
+class ReadAssetPrivilege extends \Neos\Media\Security\Authorization\Privilege\ReadAssetPrivilege
+{
+    protected function getConditionGenerator(): AssetConditionGenerator
+    {
+        return new AssetConditionGenerator();
+    }
+}

--- a/Classes/Security/Authorization/Privilege/ReadHierarchicalAssetCollectionPrivilege.php
+++ b/Classes/Security/Authorization/Privilege/ReadHierarchicalAssetCollectionPrivilege.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\Security\Authorization\Privilege;
+
+/*
+ * This file is part of the Flowpack.Media.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Flowpack\Media\Ui\Security\Authorization\Privilege\Doctrine\HierarchicalAssetCollectionConditionGenerator;
+use Neos\Media\Security\Authorization\Privilege\ReadAssetCollectionPrivilege;
+
+/**
+ * Privilege for restricting reading of HierarchicalAssetCollections
+ */
+class ReadHierarchicalAssetCollectionPrivilege extends ReadAssetCollectionPrivilege
+{
+    protected function getConditionGenerator(): HierarchicalAssetCollectionConditionGenerator
+    {
+        return new HierarchicalAssetCollectionConditionGenerator();
+    }
+}

--- a/Classes/Utility/AssetCollectionUtility.php
+++ b/Classes/Utility/AssetCollectionUtility.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\Utility;
+
+/*
+ * This file is part of the Flowpack.Media.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Behat\Transliterator\Transliterator;
+use Flowpack\Media\Ui\Domain\Model\HierarchicalAssetCollectionInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+class AssetCollectionUtility
+{
+    /**
+     * Transforms an AssetCollection title into a valid path segment by removing invalid characters and
+     * transliterating special characters if possible.
+     */
+    public static function renderValidPath(HierarchicalAssetCollectionInterface $assetCollection): string
+    {
+        $name = $assetCollection->getTitle();
+        $originalName = $name;
+
+        // Transliterate (transform 北京 to 'Bei Jing')
+        $name = Transliterator::transliterate($name);
+
+        // Urlization (replace spaces with dash, special characters)
+        $name = Transliterator::urlize($name);
+
+        // Ensure only allowed characters are left
+        $name = preg_replace('/[^a-z0-9\-]/', '', $name);
+
+        // Make sure we don't have an empty string left.
+        if ($name === '') {
+            throw new \RuntimeException('Could not render a valid path for AssetCollection with title "' . $originalName . '".');
+        }
+
+        $name = '/' . $name;
+
+        // Add path of the parent collection
+        /** @var HierarchicalAssetCollectionInterface $parent */
+        $parent = $assetCollection->getParent();
+        if ($parent !== null) {
+            // Recursively build parent path without reusing the stored parent path to ensure correct paths
+            // independent of the order of updates
+            $name = self::renderValidPath($parent) . $name;
+        }
+
+        return $name;
+    }
+}

--- a/Migrations/Mysql/Version20240222092731.php
+++ b/Migrations/Mysql/Version20240222092731.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240222092731 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds the path column to AssetCollections';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof MySqlPlatform, 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('ALTER TABLE neos_media_domain_model_assetcollection ADD path VARCHAR(1000) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof MySqlPlatform, 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('ALTER TABLE neos_media_domain_model_assetcollection DROP path');
+    }
+}

--- a/Migrations/Postgresql/Version20240223075804.php
+++ b/Migrations/Postgresql/Version20240223075804.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240223075804 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds the path column to AssetCollections';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof PostgreSQL100Platform, 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('ALTER TABLE neos_media_domain_model_assetcollection ADD path VARCHAR(1000) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof PostgreSQL100Platform, 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('ALTER TABLE neos_media_domain_model_assetcollection DROP path');
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -8,11 +8,35 @@ later replace `neos/media-browser`.
 
 If you want to use Neos, please have a look at the [Neos documentation](http://neos.readthedocs.org/en/stable/).
 
+## Screenshots
+
+### Asset management
+
+### Asset selection
+
+### Asset details
+
 ## Installation
 
 Run the following command to install it:
 
-    composer require flowpack/media-ui 
+```console
+composer require flowpack/media-ui
+``` 
+
+Afterward you should execute doctrine migrations, as the package adds new columns to the database:
+
+```console
+./flow doctrine:migrate
+```
+
+Then you should update the paths of existing asset collections:
+
+```console
+./flow assetcollections:updatepaths
+```
+
+This is only necessary once after the installation. Afterward the paths will be updated automatically.
     
 ### What changes?
 
@@ -62,6 +86,19 @@ this way create a structure comparable with folders in your computer's file syst
 
 It is recommended to enable the feature flag `limitToSingleAssetCollectionPerAsset` (see below) for a better experience - 
 see below. 
+
+The package also provides the `\Flowpack\Media\Ui\Security\Authorization\Privilege\ReadHierarchicalAssetCollectionPrivilege` 
+with the additional method `isInPath(<string>)`, which can be used to control access to the collections.
+
+```yaml
+privilegeTargets:
+  'Flowpack\Media\Ui\Security\Authorization\Privilege\ReadHierarchicalAssetCollectionPrivilege':
+    'Some.Package:ReadSpecialAssetCollectionAndSubCollections':
+      matcher: 'isInPath("/important-collections")'
+  'Flowpack\Media\Ui\Security\Authorization\Privilege\ReadAssetPrivilege':
+    'Some.Package:ReadSpecialAssets':
+      matcher: 'isInCollectionPath("/important-collections")'
+```
 
 ## Optional features
 
@@ -320,7 +357,7 @@ This way the bundle size is kept to a minimum.
 
 #### Patches
 
-Several [patches](patches) are applied during installation via [patch-package](https://github.com/ds300/patch-package).
+Several [patches](.yarn/patches) are applied during installation via [patch-package](https://github.com/ds300/patch-package).
 Additional patches can be generated and stored there with the same tool if necessary.
 
 #### Connection between the backend module and UI plugin

--- a/Resources/Private/GraphQL/schema.root.graphql
+++ b/Resources/Private/GraphQL/schema.root.graphql
@@ -275,6 +275,7 @@ type AssetCollection {
     parent: AssetCollection
     tags: [Tag!]!
     assetCount: Int!
+    path: AssetCollectionPath
 }
 
 """
@@ -437,6 +438,11 @@ scalar AssetSourceId
 Unique identifier of an Asset collection (e.g. "neos")
 """
 scalar AssetCollectionId
+
+"""
+Absolute path of an Asset collection (e.g. "/photos/trees")
+"""
+scalar AssetCollectionPath
 
 """
 Headers for asset usage metadata

--- a/Resources/Private/JavaScript/asset-collections/src/fragments/assetCollection.ts
+++ b/Resources/Private/JavaScript/asset-collections/src/fragments/assetCollection.ts
@@ -13,6 +13,7 @@ export const ASSET_COLLECTION_FRAGMENT = gql`
             ...TagProps
         }
         assetCount
+        path
     }
     ${TAG_FRAGMENT}
 `;

--- a/Resources/Private/JavaScript/asset-collections/typings/AssetCollection.ts
+++ b/Resources/Private/JavaScript/asset-collections/typings/AssetCollection.ts
@@ -12,4 +12,5 @@ interface AssetCollection extends GraphQlEntity {
     } | null;
     tags?: Tag[];
     assetCount: number;
+    path?: string;
 }


### PR DESCRIPTION
**What I did**

This change adds a new column to the collection „path“. Which allows a simple privilege check whether a user can access nested collections.

Resolves: #232

**How I did it**

Each collection has a new field "path" which is used to store the full hierarchical path of a collection.
This path can be used with the newly added privileges to limit access to collections and contained assets.

**How to verify it**

Run the following commands to make the feature work

```console
./flow doctrine:migrate
./flow assetcollections:updatepaths
```

And use&adapt the following policy for testing:

```yaml
privilegeTargets:
  'Flowpack\Media\Ui\Security\Authorization\Privilege\ReadHierarchicalAssetCollectionPrivilege':
    'Some.Package:ReadSpecialAssetCollectionAndSubCollections':
      matcher: 'isInPath("/important-collections")'
  'Flowpack\Media\Ui\Security\Authorization\Privilege\ReadAssetPrivilege':
    'Some.Package:ReadSpecialAssets':
      matcher: 'isInCollectionPath("/important-collections")'

roles:
  'Neos.Neos:AbstractEditor':
    privileges:
      - privilegeTarget: 'Some.Package:ManageImportantCollections'
        permission: DENY
      - privilegeTarget: 'Some.Package:ReadSpecialAssets'
        permission: DENY
```


Remaining todos:

- [x] Add migration for Postgres
- [x] Set path when collection is created
- [x] Fix Unittests