### PR TITLE
BUGFIX: Use http request for generating usage urls

### DIFF
--- a/Classes/Service/UsageDetailsService.php
+++ b/Classes/Service/UsageDetailsService.php
@@ -29,6 +29,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Exception as FlowException;
 use Neos\Flow\Http\Exception as HttpException;
+use Neos\Flow\Http\HttpRequestHandlerInterface;
 use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
@@ -333,7 +334,14 @@ class UsageDetailsService
      */
     protected function buildNodeUri(?Site $site, NodeInterface $node): string
     {
-        $serverRequest = $this->bootstrap->getActiveRequestHandler()->getHttpRequest();
+        $requestHandler = $this->bootstrap->getActiveRequestHandler();
+
+        if ($requestHandler instanceof HttpRequestHandlerInterface) {
+            $serverRequest = $requestHandler->getHttpRequest();
+        } else {
+            $serverRequest = ServerRequest::fromGlobals();
+        }
+
         $domain = $site ? $site->getPrimaryDomain() : null;
 
         // Build the URI with the correct scheme and hostname for the node in the given site

--- a/Classes/Service/UsageDetailsService.php
+++ b/Classes/Service/UsageDetailsService.php
@@ -26,6 +26,7 @@ use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Exception\NodeConfigurationException;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Exception as FlowException;
 use Neos\Flow\Http\Exception as HttpException;
 use Neos\Flow\I18n\Translator;
@@ -56,6 +57,12 @@ class UsageDetailsService
 {
     use CreateContentContextTrait;
     use BackendUserTranslationTrait;
+
+    /**
+     * @Flow\Inject
+     * @var Bootstrap
+     */
+    protected $bootstrap;
 
     /**
      * @Flow\Inject
@@ -326,7 +333,7 @@ class UsageDetailsService
      */
     protected function buildNodeUri(?Site $site, NodeInterface $node): string
     {
-        $serverRequest = ServerRequest::fromGlobals();
+        $serverRequest = $this->bootstrap->getActiveRequestHandler()->getHttpRequest();
         $domain = $site ? $site->getPrimaryDomain() : null;
 
         // Build the URI with the correct scheme and hostname for the node in the given site


### PR DESCRIPTION
Addresses #234

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
The usage urls now do not include the port when it is not part of the actual domain.

**How I did it**
Changing the server request for generating usage urls from the server globals to the http request of the active request.

**How to verify it**
It is working in our local, staging and production setups. When deploying to an environment where neos is running in a docker container and the domain does not include the port, then it should work correctly.

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
