### PR TITLE
FEATURE: Use custom transformer for flow exceptions

### DIFF
--- a/Classes/Transform/FlowErrorTransform.php
+++ b/Classes/Transform/FlowErrorTransform.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\Transform;
+
+use GraphQL\Error\Error;
+use GraphQL\Executor\ExecutionResult;
+use GraphQLTools\Transforms\Transform;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Log\ThrowableStorageInterface;
+
+/**
+ * This transform is used to convert exceptions to errors in the GraphQL response.
+ * To be able to localize error messages we extend the FlowErrorTransform from the t3n.GraphQL package.
+ */
+class FlowErrorTransform extends \t3n\GraphQL\Transform\FlowErrorTransform
+{
+    public function transformResult(ExecutionResult $result): ExecutionResult
+    {
+        $result->errors = array_map(function (Error $error) {
+            $previousError = $error->getPrevious();
+            if (!$previousError instanceof Error) {
+                $message = $this->throwableStorage->logThrowable($previousError);
+
+                if (!$this->includeExceptionMessageInOutput) {
+                    $message = preg_replace('/.* - See also: (.+)\.txt$/s', 'Internal error ($1)', $message);
+                }
+
+                $errorExtendedInformation = $error->getExtensions();
+                $errorExtendedInformation['errorCode'] = $previousError->getCode();
+
+                return new Error(
+                    $message,
+                    $error->getNodes(),
+                    $error->getSource(),
+                    $error->getPositions(),
+                    $error->getPath(),
+                    $previousError,
+                    $errorExtendedInformation
+                );
+            }
+
+            return $error;
+        }, $result->errors);
+
+        return $result;
+    }
+}

--- a/Configuration/Settings.GraphQL.yaml
+++ b/Configuration/Settings.GraphQL.yaml
@@ -4,6 +4,7 @@ t3n:
       'media-assets':
         logRequests: false
         context: 'Flowpack\Media\Ui\GraphQL\Context\AssetSourceContext'
+        errorTransform: 'Flowpack\Media\Ui\Transform\FlowErrorTransform'
         schemas:
           root:
             typeDefs: 'resource://Flowpack.Media.Ui/Private/GraphQL/schema.root.graphql'

--- a/Resources/Private/JavaScript/asset-collections/src/components/CreateAssetCollectionDialog.tsx
+++ b/Resources/Private/JavaScript/asset-collections/src/components/CreateAssetCollectionDialog.tsx
@@ -31,11 +31,8 @@ const CreateAssetCollectionDialog = () => {
             .then(() => {
                 Notify.ok(translate('assetCollectionActions.create.success', 'Asset collection was created'));
             })
-            .catch((error) => {
-                Notify.error(
-                    translate('assetCollectionActions.create.error', 'Failed to create asset collection'),
-                    error.message
-                );
+            .catch(() => {
+                return;
             });
     }, [setDialogVisible, createAssetCollection, title, selectedAssetCollection?.id, Notify, translate]);
 

--- a/Resources/Private/JavaScript/asset-collections/src/components/DeleteButton.tsx
+++ b/Resources/Private/JavaScript/asset-collections/src/components/DeleteButton.tsx
@@ -49,11 +49,8 @@ const DeleteButton: React.FC = () => {
                     );
                     setSelectedAssetCollectionAndTag({ tagId: null, assetCollectionId: null });
                 })
-                .catch((error) => {
-                    Notify.error(
-                        translate('assetCollectionActions.delete.error', 'Failed to delete asset collection'),
-                        error.message
-                    );
+                .catch(() => {
+                    return;
                 });
         }
     }, [

--- a/Resources/Private/JavaScript/asset-tags/src/components/CreateTagDialog.tsx
+++ b/Resources/Private/JavaScript/asset-tags/src/components/CreateTagDialog.tsx
@@ -28,8 +28,8 @@ const CreateTagDialog: React.FC = () => {
             .then(() => {
                 Notify.ok(translate('tagActions.create.success', 'Tag was created'));
             })
-            .catch((error) => {
-                Notify.error(translate('tagActions.create.error', 'Failed to create tag'), error.message);
+            .catch(() => {
+                return;
             });
     }, [Notify, setDialogState, createTag, dialogState, translate, selectedAssetCollection]);
     const setLabel = useCallback((label) => setDialogState((state) => ({ ...state, label })), [setDialogState]);

--- a/Resources/Private/JavaScript/asset-upload/src/components/Dialogs/NewAssetDialog.tsx
+++ b/Resources/Private/JavaScript/asset-upload/src/components/Dialogs/NewAssetDialog.tsx
@@ -55,8 +55,8 @@ const NewAssetDialog: React.FC = () => {
                     void refetch();
                 }
             })
-            .catch((error) => {
-                Notify.error(translate('fileUpload.error', 'Upload failed'), error);
+            .catch(() => {
+                return;
             });
     }, [uploadFiles, dialogState.files.selected, setFiles, Notify, translate, refetch]);
 

--- a/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/Main/AssetActions.tsx
@@ -29,8 +29,8 @@ const AssetActions: React.FC<ItemActionsProps> = ({ asset }: ItemActionsProps) =
             .then(() => {
                 Notify.ok(translate('assetActions.import.success', 'Asset was successfully imported'));
             })
-            .catch((error) => {
-                Notify.error(translate('assetActions.import.error', 'Failed to import asset'), error.message);
+            .catch(() => {
+                return;
             });
     }, [importAsset, asset, Notify, translate]);
 

--- a/Resources/Private/JavaScript/media-module/src/core/CreateErrorHandler.ts
+++ b/Resources/Private/JavaScript/media-module/src/core/CreateErrorHandler.ts
@@ -1,20 +1,24 @@
 import { onError } from '@apollo/client/link/error';
 
 const createErrorHandler = (notify: NeosNotification) => {
+    const translate = (id, value = null, args = {}, packageKey = 'Flowpack.Media.Ui', source = 'Main') => {
+        return window.NeosCMS.I18n.translate(id, value, packageKey, source, args);
+    };
+
     return onError(({ graphQLErrors, networkError }) => {
         if (graphQLErrors) {
             graphQLErrors.map((data) => {
-                const isInternalError = data.extensions.code === 'INTERNAL_SERVER_ERROR';
-
-                console.error(
-                    data.extensions.code === isInternalError ? '[Internal server error]' : '[GraphQL error]',
-                    data.path,
-                    data
-                );
+                const isInternalError = data.extensions.category === 'internal';
+                let errorTitleLabel = isInternalError ? 'errors.internal.title' : 'errors.graphql.title';
+                let errorMessageLabel = '';
+                if (data.extensions.errorCode) {
+                    errorTitleLabel = `errors.${data.extensions.errorCode}.title`;
+                    errorMessageLabel = `errors.${data.extensions.errorCode}.message`;
+                }
 
                 notify.error(
-                    data.extensions.code === isInternalError ? 'Internal server error' : 'Communication error',
-                    data.message
+                    translate(errorTitleLabel),
+                    errorMessageLabel.length ? translate(errorMessageLabel) : data.message
                 );
             });
         }

--- a/Resources/Private/JavaScript/media-module/src/core/CreateErrorHandler.ts
+++ b/Resources/Private/JavaScript/media-module/src/core/CreateErrorHandler.ts
@@ -9,15 +9,18 @@ const createErrorHandler = (notify: NeosNotification) => {
         if (graphQLErrors) {
             graphQLErrors.map((data) => {
                 const isInternalError = data.extensions.category === 'internal';
-                let errorTitleLabel = isInternalError ? 'errors.internal.title' : 'errors.graphql.title';
+                const defaultErrorTitle = isInternalError
+                    ? translate('errors.internal.title', 'Internal server error')
+                    : translate('errors.graphql.title', 'Communication error');
                 let errorMessageLabel = '';
+                let errorTitleLabel = '';
                 if (data.extensions.errorCode) {
                     errorTitleLabel = `errors.${data.extensions.errorCode}.title`;
                     errorMessageLabel = `errors.${data.extensions.errorCode}.message`;
                 }
 
                 notify.error(
-                    translate(errorTitleLabel),
+                    translate(errorTitleLabel, defaultErrorTitle),
                     errorMessageLabel.length ? translate(errorMessageLabel) : data.message
                 );
             });

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -45,6 +45,10 @@
                 <source>Uploading…</source>
                 <target>Hochladen…</target>
             </trans-unit>
+            <trans-unit id="uploadDialog.uploadFinished" xml:space="preserve" approved="yes">
+                <source>Upload finished</source>
+                <target>Der Upload wurde abgeschlossen</target>
+            </trans-unit>
             <trans-unit id="uploadDialog.fileList.successfulUploadsHeader" xml:space="preserve" approved="yes">
                 <source>Successful uploads</source>
                 <target>Erfolgreiche Uploads</target>
@@ -92,6 +96,18 @@
             <trans-unit id="uploadDialog.cancel" xml:space="preserve" approved="yes">
                 <source>Cancel</source>
                 <target>Abbrechen</target>
+            </trans-unit>
+            <trans-unit id="uploadDialog.uploadFinishedWithErrors" xml:space="preserve" approved="yes">
+                <source>Some files could not be uploaded</source>
+                <target>Einige Dateien konnten nicht hochgeladen werden</target>
+            </trans-unit>
+            <trans-unit id="uploadDialog.warning.fileRejected" xml:space="preserve" approved="yes">
+                <source>The given file cannot be uploaded.</source>
+                <target>Die Datei kann nicht hochgeladen werden.</target>
+            </trans-unit>
+            <trans-unit id="fileUpload.error" xml:space="preserve" approved="yes">
+                <source>Upload failed</source>
+                <target>Upload fehlgeschlagen</target>
             </trans-unit>
 
             <trans-unit id="action.selectAsset.invalidType.message" xml:space="preserve" approved="yes">
@@ -159,9 +175,25 @@
                 <source>Error while trying to delete the assets</source>
                 <target>Fehler beim Löschen der Dateien</target>
             </trans-unit>
+            <trans-unit id="actions.deleteAssets.noProxy" xml:space="preserve" approved="yes">
+                <source>Asset could not be resolved</source>
+                <target>Datei konnte nicht gefunden werden</target>
+            </trans-unit>
+            <trans-unit id="actions.deleteAssets.noImportExists" xml:space="preserve" approved="yes">
+                <source>Cannot delete asset that was never imported</source>
+                <target>Die Datei kann nicht gelöscht werden, da sie nie importiert wurde.</target>
+            </trans-unit>
+            <trans-unit id="actions.deleteAssets.success" xml:space="preserve" approved="yes">
+                <source>Asset deleted</source>
+                <target>Datei gelöscht</target>
+            </trans-unit>
             <trans-unit id="clipboard.flush" xml:space="preserve" approved="yes">
                 <source>Flush clipboard</source>
                 <target>Zwischenablage leeren</target>
+            </trans-unit>
+            <trans-unit id="clipboard.assetNotLoaded" xml:space="preserve" approved="yes">
+                <source>Cannot select asset as it couldn't be loaded</source>
+                <target>Die Datei konnte nicht geladen werden und kann daher nicht ausgewählt werden</target>
             </trans-unit>
             <trans-unit id="actions.flushClipboard.confirm.title" xml:space="preserve" approved="yes">
                 <source>Flush clipboard</source>
@@ -238,6 +270,38 @@
                 <source>Yes, proceed with deleting the asset</source>
                 <target>Ja, mit dem Löschen fortfahren</target>
             </trans-unit>
+            <trans-unit id="actions.updateAsset.success" xml:space="preserve" approved="yes">
+                <source>The asset has been updated</source>
+                <target>Die Datei wurde aktualisiert</target>
+            </trans-unit>
+            <trans-unit id="actions.deleteAsset.error" xml:space="preserve" approved="yes">
+                <source>Error while updating the asset</source>
+                <target>Fehler beim Aktualisieren der Datei</target>
+            </trans-unit>
+            <trans-unit id="actions.updateTag.success" xml:space="preserve" approved="yes">
+                <source>The tag has been updated</source>
+                <target>Der Tag wurde aktualisiert</target>
+            </trans-unit>
+            <trans-unit id="actions.updateTag.error" xml:space="preserve" approved="yes">
+                <source>Error while updating the tag</source>
+                <target>Fehler beim Aktualisieren des Tags</target>
+            </trans-unit>
+            <trans-unit id="actions.setAssetTags.success" xml:space="preserve" approved="yes">
+                <source>The asset has been tagged</source>
+                <target>Die Tags der Datei wurde aktualisiert</target>
+            </trans-unit>
+            <trans-unit id="actions.setAssetTags.error" xml:space="preserve" approved="yes">
+                <source>Error while tagging the asset</source>
+                <target>Fehler beim Taggen der Datei</target>
+            </trans-unit>
+            <trans-unit id="actions.updateAssetCollection.success" xml:space="preserve" approved="yes">
+                <source>The asset collection has been updated</source>
+                <target>Die Sammlung wurde aktualisiert</target>
+            </trans-unit>
+            <trans-unit id="actions.deleteAssetCollection.error" xml:space="preserve" approved="yes">
+                <source>Error while updating the asset collection</source>
+                <target>Fehler beim Aktualisieren der Sammlung</target>
+            </trans-unit>
 
             <!-- asset preview -->
 
@@ -300,6 +364,15 @@
                 <source>Untagged</source>
                 <target>Nicht getaggt</target>
             </trans-unit>
+            <trans-unit id="ParentCollectionSelectBox.setParent.success" xml:space="preserve" approved="yes">
+                <source>The parent collection has been set</source>
+                <target>Die übergeordnete Sammlung wurde gesetzt</target>
+            </trans-unit>
+            <trans-unit id="ParentCollectionSelectBox.setParent.error" xml:space="preserve" approved="yes">
+                <source>Error while setting the parent collection</source>
+                <target>Fehler beim Setzen der übergeordneten Sammlung</target>
+            </trans-unit>
+
 
             <!-- asset collection/tag actions -->
 
@@ -371,6 +444,15 @@
                 <source>Error while trying to delete the tag</source>
                 <target>Fehler beim Löschen des Tags</target>
             </trans-unit>
+            <trans-unit id="actions.tagAssetCollection.error" xml:space="preserve" approved="yes">
+                <source>Error while tagging the asset collection</source>
+                <target>Fehler beim Taggen der Sammlung</target>
+            </trans-unit>
+            <trans-unit id="actions.tagAssetCollection.success" xml:space="preserve" approved="yes">
+                <source>The asset collection has been tagged</source>
+                <target>Die Sammlung wurde getaggt</target>
+            </trans-unit>
+
 
             <!-- asset sources -->
 
@@ -609,6 +691,15 @@
                 <source>Identifier</source>
                 <target>Bezeichner</target>
             </trans-unit>
+            <trans-unit id="actions.setAssetCollections.success" xml:space="preserve" approved="yes">
+                <source>The collections for the asset have been set</source>
+                <target>Die Sammlungen für die Datei wurden angepasst</target>
+            </trans-unit>
+            <trans-unit id="actions.setAssetCollections.error" xml:space="preserve" approved="yes">
+                <source>Error while setting the collections for the asset</source>
+                <target>Fehler beim Anpassen der Sammlungen für die Datei</target>
+            </trans-unit>
+
 
             <!-- similar assets dialog -->
 
@@ -661,6 +752,14 @@
             <trans-unit id="editAssetDialog.updating" xml:space="preserve" approved="yes">
                 <source>Updating…</source>
                 <target>Wird geändert…</target>
+            </trans-unit>
+            <trans-unit id="EditAssetDialog.updateFinished" xml:space="preserve" approved="yes">
+                <source>Update finished</source>
+                <target>Änderung abgeschlossen</target>
+            </trans-unit>
+            <trans-unit id="EditAssetDialog.updateError" xml:space="preserve" approved="yes">
+                <source>Update failed</source>
+                <target>Änderung fehlgeschlagen</target>
             </trans-unit>
 
             <!-- Labels for the asset-usage package -->
@@ -762,6 +861,184 @@
                 <target>Gehe zu nächster Seite</target>
             </trans-unit>
 
+            <!-- error handling -->
+
+            <trans-unit id="errors.internal.title" xml:space="preserve" approved="yes">
+                <source>Internal server error</source>
+                <target>Interner Serverfehler</target>
+            </trans-unit>
+            <trans-unit id="errors.graphql.title" xml:space="preserve" approved="yes">
+                <source>Communication error</source>
+                <target>Kommunikationsfehler</target>
+            </trans-unit>
+            <trans-unit id="errors.1603921233w.title" xml:space="preserve" approved="yes">
+                <source>Failed to create tag</source>
+                <target>Tag-Erstellung fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="errors.1603921233.message" xml:space="preserve" approved="yes">
+                <source>This tag is already exists. Please choose a different one.</source>
+                <target>Dieser Tag existiert bereits. Bitte wählen Sie einen anderen aus.</target>
+            </trans-unit>
+            <trans-unit id="errors.1509632861.message" xml:space="preserve" approved="yes">
+                <source>The specified asset was not found.</source>
+                <target>Die angegebene Datei wurde nicht gefunden.</target>
+            </trans-unit>
+            <trans-unit id="errors.1678330583.message" xml:space="preserve" approved="yes">
+                <source>Parent must be an AssetCollection</source>
+                <target>Übergeordnetes Element muss eine Sammlung sein</target>
+            </trans-unit>
+            <trans-unit id="errors.1678085489.message" xml:space="preserve" approved="yes">
+                <source>Invalid metadata definition</source>
+                <target>Ungültige Metadaten-Definition</target>
+            </trans-unit>
+            <trans-unit id="errors.1591537315.message" xml:space="preserve" approved="yes">
+                <source>Failed to delete asset</source>
+                <target>Datei-Löschung fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="errors.1590659044.message" xml:space="preserve" approved="yes">
+                <source>Cannot update asset that was never imported</source>
+                <target>Die Datei kann nicht aktualisiert werden, da sie nie importiert wurde</target>
+            </trans-unit>
+            <trans-unit id="errors.1590659063.message" xml:space="preserve" approved="yes">
+                <source>Failed to update asset</source>
+                <target>Datei-Aktualisierung fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="errors.1591561758.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset that was never imported</source>
+                <target>Die Datei kann nicht getaggt werden, da sie nie importiert wurde</target>
+            </trans-unit>
+            <trans-unit id="errors.1619081662.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support tagging</source>
+                <target>Datei-Typ unterstützt keine Tags</target>
+            </trans-unit>
+            <trans-unit id="errors.1591561845.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset with tag that does not exist</source>
+                <target>Die Datei kann nicht mit einem nicht existierenden Tag versehen werden</target>
+            </trans-unit>
+            <trans-unit id="errors.1591561868.message" xml:space="preserve" approved="yes">
+                <source>Failed to update asset</source>
+                <target>Datei-Aktualisierung fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="errors.1594621322.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset that was never imported</source>
+                <target>Die Datei kann nicht getaggt werden, da sie nie importiert wurde</target>
+            </trans-unit>
+            <trans-unit id="errors.1619081714.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support tagging</source>
+                <target>Datei-Typ unterstützt keine Tags</target>
+            </trans-unit>
+            <trans-unit id="errors.1594621318.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset with tag that does not exist</source>
+                <target>Die Datei kann nicht mit einem nicht existierenden Tag versehen werden</target>
+            </trans-unit>
+            <trans-unit id="errors.1594621296.message" xml:space="preserve" approved="yes">
+                <source>Failed to set asset tags</source>
+                <target>Setzen der Datei-Tags fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="errors.1594621322.message" xml:space="preserve" approved="yes">
+                <source>Cannot assign collections to asset that was never imported</source>
+                <target>Sammlungen können nicht zu einer Datei zugewiesen werden, das nie importiert wurde</target>
+            </trans-unit>
+            <trans-unit id="errors.1619081722.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support collections</source>
+                <target>Datei-Typ unterstützt keine Sammlungen</target>
+            </trans-unit>
+            <trans-unit id="errors.1594621318.message" xml:space="preserve" approved="yes">
+                <source>Cannot assign non existing assign collection to asset</source>
+                <target>Nicht existierende Sammlung kann nicht zugewiesen werden</target>
+            </trans-unit>
+            <trans-unit id="errors.1594621296.message" xml:space="preserve" approved="yes">
+                <source>Failed to assign asset collections</source>
+                <target>Zuweisung der Datei-Sammlungen fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="errors.1591561930.message" xml:space="preserve" approved="yes">
+                <source>Cannot untag asset that was never imported</source>
+                <target>Das Tag der Datei kann nicht entfernt werden, da sie nie importiert wurde</target>
+            </trans-unit>
+            <trans-unit id="errors.1619081740.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support tagging</source>
+                <target>Datei-Typ unterstützt keine Tags</target>
+            </trans-unit>
+            <trans-unit id="errors.1591561934.message" xml:space="preserve" approved="yes">
+                <source>Cannot untag asset from tag that does not exist</source>
+                <target>Datei kann nicht von einem nicht existierenden Tag entfernt werden</target>
+            </trans-unit>
+            <trans-unit id="errors.1591561938.message" xml:space="preserve" approved="yes">
+                <source>Failed to update asset</source>
+                <target>Datei-Aktualisierung fehlgeschlagen</target>
+            </trans-unit>
+            <trans-unit id="errors.1678113903.message" xml:space="preserve" approved="yes">
+                <source>No proxy found for asset</source>
+                <target>Kein Proxy für diese Datei gefunden</target>
+            </trans-unit>
+            <trans-unit id="errors.1648046173.message" xml:space="preserve" approved="yes">
+                <source>Cannot replace asset that was never imported</source>
+                <target>Datei kann nicht ersetzt werden, da sie nie importiert wurde</target>
+            </trans-unit>
+            <trans-unit id="errors.1648046186.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support replacing</source>
+                <target>Datei-Typ unterstützt kein Ersetzen</target>
+            </trans-unit>
+            <trans-unit id="errors.1678156902.message" xml:space="preserve" approved="yes">
+                <source>Filename was empty</source>
+                <target>Dateiname war leer</target>
+            </trans-unit>
+            <trans-unit id="errors.1678113903.message" xml:space="preserve" approved="yes">
+                <source>No proxy found for asset</source>
+                <target>Kein Proxy für die Datei gefunden</target>
+            </trans-unit>
+            <trans-unit id="errors.1678155884.message" xml:space="preserve" approved="yes">
+                <source>Cannot rename asset that was never imported</source>
+                <target>Datei kann nicht umbenannt werden, da sie nie importiert wurde</target>
+            </trans-unit>
+            <trans-unit id="errors.1678155887.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support renaming</source>
+                <target>Datei-Typ unterstützt kein Umbenennen</target>
+            </trans-unit>
+            <trans-unit id="errors.1591972264.message" xml:space="preserve" approved="yes">
+                <source>Could not import asset</source>
+                <target>Datei konnte nicht importiert werden</target>
+            </trans-unit>
+            <trans-unit id="errors.1591972269.message" xml:space="preserve" approved="yes">
+                <source>Asset collection not found</source>
+                <target>Datei-Sammlung nicht gefunden</target>
+            </trans-unit>
+            <trans-unit id="errors.1590659045.message" xml:space="preserve" approved="yes">
+                <source>Asset collection not found</source>
+                <target>Datei-Sammlung nicht gefunden</target>
+            </trans-unit>
+            <trans-unit id="errors.1594621319.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset collection with tag that does not exist</source>
+                <target>Die Datei-Sammlung kann nicht mit einem nicht existierenden Tag versehen werden</target>
+            </trans-unit>
+            <trans-unit id="errors.1681999816.message" xml:space="preserve" approved="yes">
+                <source>Asset collection not found</source>
+                <target>Datei-Sammlung nicht gefunden</target>
+            </trans-unit>
+            <trans-unit id="errors.1681999836.message" xml:space="preserve" approved="yes">
+                <source>Parent asset collection not found</source>
+                <target>Übergeordnete Datei-Sammlung nicht gefunden</target>
+            </trans-unit>
+            <trans-unit id="errors.1590659046.message" xml:space="preserve" approved="yes">
+                <source>Tag not found</source>
+                <target>Tag nicht gefunden</target>
+            </trans-unit>
+            <trans-unit id="errors.1591553709.message" xml:space="preserve" approved="yes">
+                <source>Tag not found</source>
+                <target>Tag nicht gefunden</target>
+            </trans-unit>
+            <trans-unit id="errors.1669221347.message" xml:space="preserve" approved="yes">
+                <source>Not supported: AssetProxyQueryInterface::setLimit does not accept `null`.</source>
+                <target>Nicht unterstützt: AssetProxyQueryInterface::setLimit akzeptiert kein `null`.</target>
+            </trans-unit>
+            <trans-unit id="errors.1619178077.message" xml:space="preserve" approved="yes">
+                <source>This method requires "flowpack/entity-usage-databasestorage" to be installed.'</source>
+                <target>Diese Methode erfordert die Installation von "flowpack/entity-usage-databasestorage".</target>
+            </trans-unit>
+            <trans-unit id="errors.1462196420.message" xml:space="preserve" approved="yes">
+                <source>Asset could not be deleted, because it is still in use.</source>
+                <target>Die Datei konnte nicht gelöscht werden, da sie noch verwendet wird.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -35,6 +35,9 @@
             <trans-unit id="uploadDialog.label.uploading" xml:space="preserve" approved="yes">
                 <source>Uploading…</source>
             </trans-unit>
+            <trans-unit id="uploadDialog.uploadFinished" xml:space="preserve" approved="yes">
+                <source>Upload finished</source>
+            </trans-unit>
             <trans-unit id="uploadDialog.fileList.successfulUploadsHeader" xml:space="preserve" approved="yes">
                 <source>Successful uploads</source>
             </trans-unit>
@@ -70,6 +73,15 @@
             </trans-unit>
             <trans-unit id="uploadDialog.cancel" xml:space="preserve" approved="yes">
                 <source>Cancel</source>
+            </trans-unit>
+            <trans-unit id="uploadDialog.uploadFinishedWithErrors" xml:space="preserve" approved="yes">
+                <source>Some files could not be uploaded</source>
+            </trans-unit>
+            <trans-unit id="uploadDialog.warning.fileRejected" xml:space="preserve" approved="yes">
+                <source>The given file cannot be uploaded.</source>
+            </trans-unit>
+            <trans-unit id="fileUpload.error" xml:space="preserve" approved="yes">
+                <source>Upload failed</source>
             </trans-unit>
 
             <trans-unit id="action.selectAsset.invalidType.message" xml:space="preserve" approved="yes">
@@ -115,6 +127,15 @@
             <trans-unit id="actions.deleteAssets.confirm.buttonLabel" xml:space="preserve" approved="yes">
                 <source>Yes, proceed with deleting the assets</source>
             </trans-unit>
+            <trans-unit id="actions.deleteAssets.noProxy" xml:space="preserve" approved="yes">
+                <source>Asset could not be resolved</source>
+            </trans-unit>
+            <trans-unit id="actions.deleteAssets.noImportExists" xml:space="preserve" approved="yes">
+                <source>Cannot delete asset that was never imported</source>
+            </trans-unit>
+            <trans-unit id="actions.deleteAssets.success" xml:space="preserve" approved="yes">
+                <source>Asset deleted</source>
+            </trans-unit>
             <trans-unit id="clipboard.deleteAssets.success" xml:space="preserve" approved="yes">
                 <source>The assets have been deleted</source>
             </trans-unit>
@@ -123,6 +144,9 @@
             </trans-unit>
             <trans-unit id="clipboard.flush" xml:space="preserve" approved="yes">
                 <source>Flush clipboard</source>
+            </trans-unit>
+            <trans-unit id="clipboard.assetNotLoaded" xml:space="preserve" approved="yes">
+                <source>Cannot select asset as it couldn't be loaded</source>
             </trans-unit>
             <trans-unit id="actions.flushClipboard.confirm.title" xml:space="preserve" approved="yes">
                 <source>Flush clipboard</source>
@@ -181,6 +205,30 @@
             <trans-unit id="actions.deleteAsset.confirm.buttonLabel" xml:space="preserve" approved="yes">
                 <source>Yes, proceed with deleting the asset</source>
             </trans-unit>
+            <trans-unit id="actions.updateAsset.success" xml:space="preserve" approved="yes">
+                <source>The asset has been updated</source>
+            </trans-unit>
+            <trans-unit id="actions.deleteAsset.error" xml:space="preserve" approved="yes">
+                <source>Error while updating the asset</source>
+            </trans-unit>
+            <trans-unit id="actions.updateTag.success" xml:space="preserve" approved="yes">
+                <source>The tag has been updated</source>
+            </trans-unit>
+            <trans-unit id="actions.updateTag.error" xml:space="preserve" approved="yes">
+                <source>Error while updating the tag</source>
+            </trans-unit>
+            <trans-unit id="actions.setAssetTags.success" xml:space="preserve" approved="yes">
+                <source>The asset has been tagged</source>
+            </trans-unit>
+            <trans-unit id="actions.setAssetTags.error" xml:space="preserve" approved="yes">
+                <source>Error while tagging the asset</source>
+            </trans-unit>
+            <trans-unit id="actions.updateAssetCollection.success" xml:space="preserve" approved="yes">
+                <source>The asset collection has been updated</source>
+            </trans-unit>
+            <trans-unit id="actions.deleteAssetCollection.error" xml:space="preserve" approved="yes">
+                <source>Error while updating the asset collection</source>
+            </trans-unit>
 
             <!-- asset preview -->
 
@@ -228,6 +276,12 @@
             </trans-unit>
             <trans-unit id="assetCollectionList.untagged" xml:space="preserve" approved="yes">
                 <source>Untagged</source>
+            </trans-unit>
+            <trans-unit id="ParentCollectionSelectBox.setParent.success" xml:space="preserve" approved="yes">
+                <source>The parent collection has been set</source>
+            </trans-unit>
+            <trans-unit id="ParentCollectionSelectBox.setParent.error" xml:space="preserve" approved="yes">
+                <source>Error while setting the parent collection</source>
             </trans-unit>
 
             <!-- asset collection/tag actions -->
@@ -282,6 +336,12 @@
             </trans-unit>
             <trans-unit id="action.deleteTag.error" xml:space="preserve" approved="yes">
                 <source>Error while trying to delete the tag</source>
+            </trans-unit>
+            <trans-unit id="actions.tagAssetCollection.error" xml:space="preserve" approved="yes">
+                <source>Error while tagging the asset collection</source>
+            </trans-unit>
+            <trans-unit id="actions.tagAssetCollection.success" xml:space="preserve" approved="yes">
+                <source>The asset collection has been tagged</source>
             </trans-unit>
 
             <!-- asset sources -->
@@ -467,6 +527,12 @@
             <trans-unit id="inspector.iptcMetadata" xml:space="preserve" approved="yes">
                 <source>IPTC Metadata</source>
             </trans-unit>
+            <trans-unit id="actions.setAssetCollections.success" xml:space="preserve" approved="yes">
+                <source>The collections for the asset have been set</source>
+            </trans-unit>
+            <trans-unit id="actions.setAssetCollections.error" xml:space="preserve" approved="yes">
+                <source>Error while setting the collections for the asset</source>
+            </trans-unit>
 
             <!-- similar assets dialog -->
 
@@ -508,6 +574,12 @@
             </trans-unit>
             <trans-unit id="editAssetDialog.updating" xml:space="preserve" approved="yes">
                 <source>Updating…</source>
+            </trans-unit>
+            <trans-unit id="EditAssetDialog.updateFinished" xml:space="preserve" approved="yes">
+                <source>Update finished</source>
+            </trans-unit>
+            <trans-unit id="EditAssetDialog.updateError" xml:space="preserve" approved="yes">
+                <source>Update failed</source>
             </trans-unit>
 
             <!-- Labels for the asset-usage package -->
@@ -594,13 +666,132 @@
             <trans-unit id="errors.graphql.title" xml:space="preserve" approved="yes">
                 <source>Communication error</source>
             </trans-unit>
-            <trans-unit id="errors.1603921233.title" xml:space="preserve" approved="yes">
+            <trans-unit id="errors.1603921233w.title" xml:space="preserve" approved="yes">
                 <source>Failed to create tag</source>
             </trans-unit>
             <trans-unit id="errors.1603921233.message" xml:space="preserve" approved="yes">
                 <source>This tag is already exists. Please choose a different one.</source>
             </trans-unit>
-
+            <trans-unit id="errors.1509632861.message" xml:space="preserve" approved="yes">
+                <source>The specified asset was not found.</source>
+            </trans-unit>
+            <trans-unit id="errors.1678330583.message" xml:space="preserve" approved="yes">
+                <source>Parent must be an AssetCollection</source>
+            </trans-unit>
+            <trans-unit id="errors.1678085489.message" xml:space="preserve" approved="yes">
+                <source>Invalid metadata definition</source>
+            </trans-unit>
+            <trans-unit id="errors.1591537315.message" xml:space="preserve" approved="yes">
+                <source>Failed to delete asset</source>
+            </trans-unit>
+            <trans-unit id="errors.1590659044.message" xml:space="preserve" approved="yes">
+                <source>Cannot update asset that was never imported</source>
+            </trans-unit>
+            <trans-unit id="errors.1590659063.message" xml:space="preserve" approved="yes">
+                <source>Failed to update asset</source>
+            </trans-unit>
+            <trans-unit id="errors.1591561758.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset that was never imported</source>
+            </trans-unit>
+            <trans-unit id="errors.1619081662.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support tagging</source>
+            </trans-unit>
+            <trans-unit id="errors.1591561845.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset with tag that does not exist</source>
+            </trans-unit>
+            <trans-unit id="errors.1591561868.message" xml:space="preserve" approved="yes">
+                <source>Failed to update asset</source>
+            </trans-unit>
+            <trans-unit id="errors.1594621322.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset that was never imported</source>
+            </trans-unit>
+            <trans-unit id="errors.1619081714.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support tagging</source>
+            </trans-unit>
+            <trans-unit id="errors.1594621318.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset with tag that does not exist</source>
+            </trans-unit>
+            <trans-unit id="errors.1594621296.message" xml:space="preserve" approved="yes">
+                <source>Failed to set asset tags</source>
+            </trans-unit>
+            <trans-unit id="errors.1594621322.message" xml:space="preserve" approved="yes">
+                <source>Cannot assign collections to asset that was never imported</source>
+            </trans-unit>
+            <trans-unit id="errors.1619081722.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support collections</source>
+            </trans-unit>
+            <trans-unit id="errors.1594621318.message" xml:space="preserve" approved="yes">
+                <source>Cannot assign non existing assign collection to asset</source>
+            </trans-unit>
+            <trans-unit id="errors.1594621296.message" xml:space="preserve" approved="yes">
+                <source>Failed to assign asset collections</source>
+            </trans-unit>
+            <trans-unit id="errors.1591561930.message" xml:space="preserve" approved="yes">
+                <source>Cannot untag asset that was never imported</source>
+            </trans-unit>
+            <trans-unit id="errors.1619081740.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support tagging</source>
+            </trans-unit>
+            <trans-unit id="errors.1591561934.message" xml:space="preserve" approved="yes">
+                <source>Cannot untag asset from tag that does not exist</source>
+            </trans-unit>
+            <trans-unit id="errors.1591561938.message" xml:space="preserve" approved="yes">
+                <source>Failed to update asset</source>
+            </trans-unit>
+            <trans-unit id="errors.1678113903.message" xml:space="preserve" approved="yes">
+                <source>No proxy found for asset</source>
+            </trans-unit>
+            <trans-unit id="errors.1648046173.message" xml:space="preserve" approved="yes">
+                <source>Cannot replace asset that was never imported</source>
+            </trans-unit>
+            <trans-unit id="errors.1648046186.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support replacing</source>
+            </trans-unit>
+            <trans-unit id="errors.1678156902.message" xml:space="preserve" approved="yes">
+                <source>Filename was empty</source>
+            </trans-unit>
+            <trans-unit id="errors.1678113903.message" xml:space="preserve" approved="yes">
+                <source>No proxy found for asset</source>
+            </trans-unit>
+            <trans-unit id="errors.1678155884.message" xml:space="preserve" approved="yes">
+                <source>Cannot rename asset that was never imported</source>
+            </trans-unit>
+            <trans-unit id="errors.1678155887.message" xml:space="preserve" approved="yes">
+                <source>Asset type does not support renaming</source>
+            </trans-unit>
+            <trans-unit id="errors.1591972264.message" xml:space="preserve" approved="yes">
+                <source>Could not import asset</source>
+            </trans-unit>
+            <trans-unit id="errors.1591972269.message" xml:space="preserve" approved="yes">
+                <source>Asset collection not found</source>
+            </trans-unit>
+            <trans-unit id="errors.1590659045.message" xml:space="preserve" approved="yes">
+                <source>Asset collection not found</source>
+            </trans-unit>
+            <trans-unit id="errors.1594621319.message" xml:space="preserve" approved="yes">
+                <source>Cannot tag asset collection with tag that does not exist</source>
+            </trans-unit>
+            <trans-unit id="errors.1681999816.message" xml:space="preserve" approved="yes">
+                <source>Asset collection not found</source>
+            </trans-unit>
+            <trans-unit id="errors.1681999836.message" xml:space="preserve" approved="yes">
+                <source>Parent asset collection not found</source>
+            </trans-unit>
+            <trans-unit id="errors.1590659046.message" xml:space="preserve" approved="yes">
+                <source>Tag not found</source>
+            </trans-unit>
+            <trans-unit id="errors.1591553709.message" xml:space="preserve" approved="yes">
+                <source>Tag not found</source>
+            </trans-unit>
+            <trans-unit id="errors.1669221347.message" xml:space="preserve" approved="yes">
+                <source>Not supported: AssetProxyQueryInterface::setLimit does not accept `null`.</source>
+            </trans-unit>
+            <trans-unit id="errors.1619178077.message" xml:space="preserve" approved="yes">
+                <source>This method requires "flowpack/entity-usage-databasestorage" to be installed.</source>
+            </trans-unit>
+            <trans-unit id="errors.1462196420.message" xml:space="preserve" approved="yes">
+                <source>Asset could not be deleted, because it is still in use.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -586,6 +586,21 @@
                 <source>Go to next page</source>
             </trans-unit>
 
+            <!-- error handling -->
+
+            <trans-unit id="errors.internal.title" xml:space="preserve" approved="yes">
+                <source>Internal server error</source>
+            </trans-unit>
+            <trans-unit id="errors.graphql.title" xml:space="preserve" approved="yes">
+                <source>Communication error</source>
+            </trans-unit>
+            <trans-unit id="errors.1603921233.title" xml:space="preserve" approved="yes">
+                <source>Failed to create tag</source>
+            </trans-unit>
+            <trans-unit id="errors.1603921233.message" xml:space="preserve" approved="yes">
+                <source>This tag is already exists. Please choose a different one.</source>
+            </trans-unit>
+
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
The t3n GraphQL package includes a transformer that bypasses Flow Framework exceptions in GraphQL error handling. The error currently lacks the exception code as part of the information. By including this code (often a timestamp), we can render custom error messages in the backend and support localization.

<img width="1456" alt="Screenshot 2024-10-23 at 12 27 54" src="https://github.com/user-attachments/assets/47965602-737b-4762-a65a-0959325ec222">


Relates: #240 