### PR TITLE
FEATURE: Auto assign new assets to default collection and prevent removing last collection depending on config

### DIFF
--- a/Classes/GraphQL/Resolver/Type/MutationResolver.php
+++ b/Classes/GraphQL/Resolver/Type/MutationResolver.php
@@ -408,9 +408,12 @@ class MutationResolver implements ResolverInterface
                         if ($assetCollectionId) {
                             /** @var AssetCollection $assetCollection */
                             $assetCollection = $this->assetCollectionRepository->findByIdentifier($assetCollectionId);
-                            if ($assetCollection) {
-                                $asset->setAssetCollections(new ArrayCollection([$assetCollection]));
-                            }
+                        } else {
+                            // Assign the asset to the asset collection of the site it has been uploaded to
+                            $assetCollection = $this->assetCollectionService->getDefaultCollectionForCurrentSite();
+                        }
+                        if ($assetCollection) {
+                            $asset->setAssetCollections(new ArrayCollection([$assetCollection]));
                         }
 
                         $this->assetRepository->add($asset);

--- a/Classes/GraphQL/Resolver/Type/QueryResolver.php
+++ b/Classes/GraphQL/Resolver/Type/QueryResolver.php
@@ -19,6 +19,7 @@ use Flowpack\Media\Ui\Exception as MediaUiException;
 use Flowpack\Media\Ui\GraphQL\Context\AssetSourceContext;
 use Flowpack\Media\Ui\Infrastructure\Neos\Media\AssetProxyIteratorBuilder;
 use Flowpack\Media\Ui\Service\AssetChangeLog;
+use Flowpack\Media\Ui\Service\AssetCollectionService;
 use Flowpack\Media\Ui\Service\SimilarityService;
 use Flowpack\Media\Ui\Service\UsageDetailsService;
 use Neos\Flow\Annotations as Flow;
@@ -115,6 +116,12 @@ class QueryResolver implements ResolverInterface
     protected $privilegeManager;
 
     /**
+     * @Flow\Inject
+     * @var AssetCollectionService
+     */
+    protected $assetCollectionService;
+
+    /**
      * Returns total count of asset proxies in the given asset source
      * @noinspection PhpUnusedParameterInspection
      */
@@ -185,10 +192,13 @@ class QueryResolver implements ResolverInterface
      */
     public function config($_): array
     {
+        $defaultAssetCollection = $this->assetCollectionService->getDefaultCollectionForCurrentSite();
+
         return [
             'uploadMaxFileSize' => $this->getMaximumFileUploadSize(),
             'uploadMaxFileUploadLimit' => $this->getMaximumFileUploadLimit(),
             'currentServerTime' => (new \DateTime())->format(DATE_W3C),
+            'defaultAssetCollectionId' => $defaultAssetCollection ? $this->persistenceManager->getIdentifierByObject($defaultAssetCollection) : null,
             'canManageTags' => $this->privilegeManager->isPrivilegeTargetGranted('Flowpack.Media.Ui:ManageTags'),
             'canManageAssetCollections' => $this->privilegeManager->isPrivilegeTargetGranted('Flowpack.Media.Ui:ManageAssetCollections'),
             'canManageAssets' => $this->privilegeManager->isPrivilegeTargetGranted('Flowpack.Media.Ui:ManageAssets'),

--- a/Classes/Service/AssetCollectionService.php
+++ b/Classes/Service/AssetCollectionService.php
@@ -8,9 +8,12 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Flowpack\Media\Ui\Domain\Model\HierarchicalAssetCollectionInterface;
 use Flowpack\Media\Ui\Utility\AssetCollectionUtility;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
+use Neos\Neos\Domain\Service\ContentContext;
 
 /**
  * @Flow\Scope("singleton")
@@ -36,6 +39,12 @@ class AssetCollectionService
      * @var AssetCollectionRepository
      */
     protected $assetCollectionRepository;
+
+    /**
+     * @Flow\Inject
+     * @var ContextFactoryInterface
+     */
+    protected $contextFactory;
 
     /**
      * Queries the asset count for all asset collections once and caches the result.
@@ -84,5 +93,18 @@ class AssetCollectionService
             $this->assetCollectionRepository->update($childCollection);
             $this->updatePathForNestedAssetCollections($childCollection);
         }
+    }
+
+    /**
+     * Returns the default asset collection for the current site if available
+     */
+    public function getDefaultCollectionForCurrentSite(): ?AssetCollection
+    {
+        /** @var ContentContext $context */
+        $context = $this->contextFactory->create([
+            'workspaceName' => 'live',
+        ]);
+
+        return $context->getCurrentSite()?->getAssetCollection();
     }
 }

--- a/Resources/Private/GraphQL/schema.root.graphql
+++ b/Resources/Private/GraphQL/schema.root.graphql
@@ -164,6 +164,7 @@ type Config {
     uploadMaxFileSize: FileSize!
     uploadMaxFileUploadLimit: Int!
     currentServerTime: DateTime!
+    defaultAssetCollectionId: AssetCollectionId
     canManageAssetCollections: Boolean!
     canManageTags: Boolean!
     canManageAssets: Boolean!

--- a/Resources/Private/JavaScript/core/src/hooks/useConfigQuery.ts
+++ b/Resources/Private/JavaScript/core/src/hooks/useConfigQuery.ts
@@ -7,6 +7,7 @@ interface ConfigQueryResult {
         uploadMaxFileSize: number;
         uploadMaxFileUploadLimit: number;
         currentServerTime: Date;
+        defaultAssetCollectionId: AssetCollectionId | null;
         canManageAssetCollections: boolean;
         canManageTags: boolean;
         canManageAssets: boolean;
@@ -18,6 +19,7 @@ const DEFAULT_CONFIG: ConfigQueryResult = {
         uploadMaxFileSize: 0,
         uploadMaxFileUploadLimit: 0,
         currentServerTime: new Date(),
+        defaultAssetCollectionId: null,
         canManageAssetCollections: false,
         canManageTags: false,
         canManageAssets: false,

--- a/Resources/Private/JavaScript/core/src/queries/config.ts
+++ b/Resources/Private/JavaScript/core/src/queries/config.ts
@@ -6,6 +6,7 @@ const CONFIG = gql`
             uploadMaxFileSize
             uploadMaxFileUploadLimit
             currentServerTime
+            defaultAssetCollectionId
             canManageAssetCollections
             canManageTags
             canManageAssets

--- a/Resources/Private/JavaScript/dev-server/src/server.ts
+++ b/Resources/Private/JavaScript/dev-server/src/server.ts
@@ -164,6 +164,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
                 uploadMaxFileSize: 1024 * 1024,
                 uploadMaxFileUploadLimit: 2,
                 currentServerTime: new Date(),
+                defaultAssetCollectionId: null,
                 canManageAssetCollections: true,
                 canManageTags: true,
                 canManageAssets: true,

--- a/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/CollectionSelectBox.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/CollectionSelectBox.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil';
 import { Headline, MultiSelectBox, SelectBox } from '@neos-project/react-ui-components';
 
 import { useIntl, useNotify, useMediaUi } from '@media-ui/core';
-import { useSelectedAsset, useSetAssetCollections } from '@media-ui/core/src/hooks';
+import { useConfigQuery, useSelectedAsset, useSetAssetCollections } from '@media-ui/core/src/hooks';
 import { IconLabel } from '@media-ui/core/src/components';
 import { featureFlagsState } from '@media-ui/core/src/state';
 import { collectionPath, useAssetCollectionsQuery } from '@media-ui/feature-asset-collections';
@@ -19,6 +19,7 @@ const collectionsMatchAsset = (assetCollectionIds: string[], asset: Asset) => {
 const CollectionSelectBox: React.FC = () => {
     const Notify = useNotify();
     const { translate } = useIntl();
+    const { config } = useConfigQuery();
     const {
         approvalAttainmentStrategy: { obtainApprovalToSetAssetCollections },
     } = useMediaUi();
@@ -136,7 +137,7 @@ const CollectionSelectBox: React.FC = () => {
                         onSearchTermChange={handleSearchTermChange}
                         ListPreviewElement={AssetCollectionOptionPreviewElement}
                         displaySearchBox
-                        allowEmpty
+                        allowEmpty={false}
                         threshold={0}
                     />
                 </>
@@ -158,7 +159,7 @@ const CollectionSelectBox: React.FC = () => {
                         onSearchTermChange={handleSearchTermChange}
                         ListPreviewElement={AssetCollectionOptionPreviewElement}
                         displaySearchBox
-                        allowEmpty
+                        allowEmpty={!config.defaultAssetCollectionId}
                         threshold={0}
                     />
                 </>

--- a/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/ParentCollectionSelectBox.tsx
+++ b/Resources/Private/JavaScript/media-module/src/components/SideBarRight/Inspector/ParentCollectionSelectBox.tsx
@@ -4,7 +4,6 @@ import { Headline, SelectBox } from '@neos-project/react-ui-components';
 
 import { useIntl, useMediaUi, useNotify } from '@media-ui/core';
 import { IconLabel } from '@media-ui/core/src/components';
-import { useConfigQuery } from '@media-ui/core/src/hooks';
 import {
     collectionPath,
     useAssetCollectionsQuery,
@@ -18,7 +17,6 @@ import * as classes from './ParentCollectionSelectBox.module.css';
 
 const ParentCollectionSelectBox = () => {
     const Notify = useNotify();
-    const { config } = useConfigQuery();
     const { translate } = useIntl();
     const { approvalAttainmentStrategy } = useMediaUi();
     const { assetCollections } = useAssetCollectionsQuery();
@@ -98,7 +96,7 @@ const ParentCollectionSelectBox = () => {
             </Headline>
             <SelectBox
                 className={classes.collectionSelectBox}
-                disabled={!config.canManageAssetCollections || loading}
+                disabled={loading || filteredSelectBoxOptions.length === 0}
                 placeholder={translate('inspector.collections.placeholder', 'Select a collection')}
                 value={selectedAssetCollection.parent?.id}
                 optionValueField="id"


### PR DESCRIPTION
The old media browser auto assigned assets without a collection to the default collection of a site if one is configured. This behaviour has now been duplicated.

Also It's now impossible to remove the last collection of an asset in "folder mode" and when a default collection is configured for the current site.

Resolves: #246 

Based on: #245 