### PR TITLE
BUGFIX: Explicit marking of nullable parameter

### DIFF
--- a/Classes/Domain/Model/AssetSource/NeosAssetProxyRepository.php
+++ b/Classes/Domain/Model/AssetSource/NeosAssetProxyRepository.php
@@ -111,7 +111,7 @@ final class NeosAssetProxyRepository implements AssetProxyRepositoryInterface, S
         $this->assetRepository->setDefaultOrderings($orderings);
     }
 
-    public function filterByType(AssetTypeFilter $assetType = null): void
+    public function filterByType(?AssetTypeFilter $assetType = null): void
     {
         $this->assetTypeFilter = (string)$assetType ?: 'All';
         $this->initializeObject();
@@ -126,7 +126,7 @@ final class NeosAssetProxyRepository implements AssetProxyRepositoryInterface, S
      * NOTE: This needs to be refactored to use an asset collection identifier instead of Media's domain model before
      *       it can become a public API for other asset sources.
      */
-    public function filterByCollection(AssetCollection $assetCollection = null): void
+    public function filterByCollection(?AssetCollection $assetCollection = null): void
     {
         $this->activeAssetCollection = $assetCollection;
     }

--- a/Classes/Domain/Model/Dto/MutationResult.php
+++ b/Classes/Domain/Model/Dto/MutationResult.php
@@ -16,7 +16,7 @@ class MutationResult implements \JsonSerializable
     private ?array $messages;
     private ?array $data;
 
-    public function __construct(bool $success, array $messages = null, array $data = null)
+    public function __construct(bool $success, ?array $messages = null, ?array $data = null)
     {
         $this->success = $success;
         $this->messages = $messages;


### PR DESCRIPTION
To get rid of PHP 8.4 deprecation warnings