### PR TITLE
BUGFIX: Add bottom margin for thumbnail view so it doesn't overlap with pagination in link editor/media selection view

### DIFF
--- a/packages/media-module/src/components/Main/ThumbnailView.module.css
+++ b/packages/media-module/src/components/Main/ThumbnailView.module.css
@@ -3,3 +3,7 @@
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: var(--theme-spacing-Full);
 }
+
+.thumbnailViewInSelectionMode {
+    padding-bottom: 41px;
+}

--- a/packages/media-module/src/components/Main/ThumbnailView.tsx
+++ b/packages/media-module/src/components/Main/ThumbnailView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { useSetRecoilState } from 'recoil';
+import cx from 'classnames';
 
 import { useSelectAsset } from '@media-ui/core/src/hooks';
 import { selectedAssetForPreviewState } from '@media-ui/feature-asset-preview';
@@ -7,6 +8,7 @@ import { selectedAssetForPreviewState } from '@media-ui/feature-asset-preview';
 import { Thumbnail } from './index';
 
 import classes from './ThumbnailView.module.css';
+import { useMediaUi } from '@media-ui/core';
 
 interface ThumbnailViewProps {
     assetIdentities: AssetIdentity[];
@@ -15,6 +17,7 @@ interface ThumbnailViewProps {
 const ThumbnailView: React.FC<ThumbnailViewProps> = ({ assetIdentities }: ThumbnailViewProps) => {
     const setSelectedAssetForPreview = useSetRecoilState(selectedAssetForPreviewState);
     const selectAsset = useSelectAsset();
+    const { selectionMode } = useMediaUi();
 
     const onSelect = useCallback(
         (assetIdentity: AssetIdentity, openPreview = false) => {
@@ -28,7 +31,7 @@ const ThumbnailView: React.FC<ThumbnailViewProps> = ({ assetIdentities }: Thumbn
     );
 
     return (
-        <section className={classes.thumbnailView}>
+        <section className={cx(classes.thumbnailView, selectionMode && classes.thumbnailViewInSelectionMode)}>
             {assetIdentities.map((assetIdentity, index) => (
                 <Thumbnail key={index} assetIdentity={assetIdentity} onSelect={onSelect} />
             ))}


### PR DESCRIPTION
**What I did**

I added 4rem of margin-bottom to ThumbnailView, because in a selection view the last line of filenames was not readable due to it being hidden behind the pagination.

<img width="1208" height="1100" alt="image (18)" src="https://github.com/user-attachments/assets/e0e93dd8-0511-4c6b-ae3c-d62724a1af3b" />

**How I did it**

I added 4rem of margin-bottom to ThumbnailView.module.css.