### PR TITLE
BUGFIX: Correct asset download url

### DIFF
--- a/Classes/GraphQL/Resolver/Type/AssetResolver.php
+++ b/Classes/GraphQL/Resolver/Type/AssetResolver.php
@@ -109,8 +109,7 @@ class AssetResolver
 
         $icon = $this->fileTypeIconService::getIcon($assetProxy->getFilename());
 
-        if ($asset instanceof ProvidesOriginalUriInterface) {
-            /** @phpstan-ignore method.notFound */
+        if ($assetProxy instanceof ProvidesOriginalUriInterface) {
             $url = (string)$assetProxy->getOriginalUri();
         } else {
             $url = (string)$assetProxy->getPreviewUri();


### PR DESCRIPTION
**What I did**
fix that  download always dowloaded the preview png instead of file
#259 

**How I did it**
changed $asset to $assetProxy in condition
I found ProvidesOriginalUriInterface is only implemented in NeosAssetProxy so that makes sense

**How to verify it**
Download of pdf works again for example
