### PR TITLE
TASK: Ensure we use es module version instead of cjs from third party…

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+.cache
+dist
+esbuild.js
+node_modules

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,6 @@ module.exports = {
         es2020: true,
         node: true,
     },
-    ignorePatterns: ['.cache', '.parcel-cache', 'dist'],
     rules: {
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, '2.x', '2.x-dev' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, '2.x', '2.x-dev' ]
 
 env:
   YARN_ENABLE_IMMUTABLE_INSTALLS: false

--- a/packages/dev-server/src/server.ts
+++ b/packages/dev-server/src/server.ts
@@ -22,6 +22,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
         minify: false,
         keepNames: true,
         sourcemap: 'linked',
+        mainFields: ['browser', 'module', 'main'],
         target: 'es2020',
         entryPoints: {
             server: path.resolve(__dirname, './index.ts'),

--- a/packages/dev-server/src/server.ts
+++ b/packages/dev-server/src/server.ts
@@ -16,7 +16,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 (async () => {
     const frontendPort = 8000;
 
-    const options = {
+    const options: esbuild.BuildOptions = {
         logLevel: 'info',
         bundle: true,
         minify: false,

--- a/packages/media-module/esbuild.js
+++ b/packages/media-module/esbuild.js
@@ -1,5 +1,6 @@
 const esbuild = require('esbuild');
 const isWatch = process.argv.includes('--watch');
+const isAnalyze = process.argv.includes('--analyze');
 
 /** @type {import("esbuild").BuildOptions} */
 const options = {
@@ -9,6 +10,8 @@ const options = {
     sourcemap: 'linked',
     legalComments: 'linked',
     target: 'es2020',
+    metafile: isAnalyze,
+    mainFields: ['browser', 'module', 'main'],
     entryPoints: {
         'main.bundle': './src/index.tsx',
     },
@@ -22,5 +25,10 @@ const options = {
 if (isWatch) {
     esbuild.context(options).then((ctx) => ctx.watch());
 } else {
-    esbuild.build(options);
+    esbuild.build(options).then((result) => {
+        if (isAnalyze) {
+            require('fs').writeFileSync('meta.json', JSON.stringify(result.metafile));
+            console.log("\nUpload './meta.json' to https://esbuild.github.io/analyze/ to analyze the bundle.");
+        }
+    });
 }

--- a/packages/media-module/esbuild.js
+++ b/packages/media-module/esbuild.js
@@ -1,4 +1,5 @@
 const esbuild = require('esbuild');
+const CssModulesPlugin = require("esbuild-css-modules-plugin");
 const isWatch = process.argv.includes('--watch');
 const isAnalyze = process.argv.includes('--analyze');
 
@@ -15,6 +16,15 @@ const options = {
     entryPoints: {
         'main.bundle': './src/index.tsx',
     },
+    plugins: [
+        CssModulesPlugin({
+            // @see https://github.com/indooorsman/esbuild-css-modules-plugin/blob/main/index.d.ts for more details
+            force: true,
+            localsConvention: 'camelCaseOnly',
+            namedExports: true,
+            inject: false,
+        }),
+    ],
     outdir: '../../Resources/Public/Assets',
     define: {
         // react-image-lightbox

--- a/packages/media-module/src/components/TopBar/SearchBox.tsx
+++ b/packages/media-module/src/components/TopBar/SearchBox.tsx
@@ -27,7 +27,7 @@ const SearchBox: React.FC = () => {
         setSearchValue('');
         setSearchTerm(SearchTerm.fromString(''));
         setCurrentPage(1);
-    }, [setSearchValue, setSearchTerm, handleSearch]);
+    }, [setCurrentPage, setSearchValue, setSearchTerm]);
 
     if (mainView !== MainViewMode.DEFAULT) return null;
 

--- a/packages/neos-ui-plugin/esbuild.js
+++ b/packages/neos-ui-plugin/esbuild.js
@@ -2,6 +2,7 @@ const esbuild = require('esbuild');
 const CssModulesPlugin = require('esbuild-css-modules-plugin');
 const extensibilityMap = require('@neos-project/neos-ui-extensibility/extensibilityMap.json');
 const isWatch = process.argv.includes('--watch');
+const isAnalyze = process.argv.includes('--analyze');
 
 /** @type {import("esbuild").BuildOptions} */
 const options = {
@@ -11,6 +12,8 @@ const options = {
     minify: !isWatch,
     legalComments: 'linked',
     target: 'es2020',
+    mainFields: ['browser', 'module', 'main'],
+    metafile: isAnalyze,
     entryPoints: {
         Plugin: './src/manifest.js',
     },
@@ -21,7 +24,8 @@ const options = {
     },
     plugins: [
         CssModulesPlugin({
-            // @see https://github.com/indooorsman/esbuild-css-modules-plugin/blob/main/index.d.ts for more details
+            // we cant use esbuild local-css feature as the resulting CSS classes are likely overridden by another plugin https://github.com/evanw/esbuild/issues/3484
+            pattern: `media-[hash]_[local]`,
             force: true,
             localsConvention: 'camelCaseOnly',
             namedExports: true,
@@ -34,5 +38,10 @@ const options = {
 if (isWatch) {
     esbuild.context(options).then((ctx) => ctx.watch());
 } else {
-    esbuild.build(options);
+    esbuild.build(options).then((result) => {
+        if (isAnalyze) {
+            require('fs').writeFileSync('meta.json', JSON.stringify(result.metafile));
+            console.log("\nUpload './meta.json' to https://esbuild.github.io/analyze/ to analyze the bundle.");
+        }
+    });
 }


### PR DESCRIPTION
… (especially apollo and graphql)

Otherwise `main` takes precedence:
https://esbuild.github.io/api/#platform

We save approximately 500kb and now are reduced to 442kb (plugin) and (911kb) module

Followup to #269 

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
