### PR TITLE
Bugfix: Link to user workspace instead of live workspace in usage list

### DIFF
--- a/Classes/Service/UsageDetailsService.php
+++ b/Classes/Service/UsageDetailsService.php
@@ -34,6 +34,8 @@ use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Exception as FlowException;
 use Neos\Flow\Http\Exception as HttpException;
 use Neos\Flow\Http\HttpRequestHandlerInterface;
+use Neos\Flow\I18n\Exception\IndexOutOfBoundsException;
+use Neos\Flow\I18n\Exception\InvalidFormatPlaceholderException;
 use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
@@ -232,7 +234,9 @@ final class UsageDetailsService
     {
         $dimensionValues = [];
         foreach ($node->getDimensions() as $dimensionName => $dimensionValuesForName) {
-            $dimensionValues[$this->contentDimensionsConfiguration[$dimensionName]['label'] ?? $dimensionName] = array_map(function (
+            $dimensionLabel = $this->translateById(
+                $this->contentDimensionsConfiguration[$dimensionName]['label'] ?? $dimensionName);
+            $dimensionValues[$dimensionLabel] = array_map(function (
                 $dimensionValue
             ) use ($dimensionName) {
                 return $this->contentDimensionsConfiguration[$dimensionName]['presets'][$dimensionValue]['label'] ?? $dimensionValue;
@@ -433,9 +437,28 @@ final class UsageDetailsService
             ->getSingleScalarResult();
     }
 
+    /**
+     * @throws InvalidFormatPlaceholderException
+     * @throws IndexOutOfBoundsException
+     */
     protected function translateById(string $id): ?string
     {
-        return $this->translator->translateById($id, [], null, null, 'Main', 'Flowpack.Media.Ui') ?? $id;
+        $source = 'Main';
+        $package = 'Flowpack.Media.Ui';
+
+        $shortHandStringParts = explode(':', $id);
+        if (count($shortHandStringParts) === 3) {
+            [$package, $source, $id] = $shortHandStringParts;
+        }
+
+        return $this->translator->translateById(
+            $id,
+            [],
+            null,
+            null,
+            $source,
+            $package,
+        ) ?? $id;
     }
 
     /**

--- a/Classes/Service/UsageDetailsService.php
+++ b/Classes/Service/UsageDetailsService.php
@@ -26,6 +26,7 @@ use GuzzleHttp\Psr7\Uri;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Exception\NodeConfigurationException;
 use Neos\Flow\Annotations as Flow;
@@ -65,6 +66,9 @@ final class UsageDetailsService
 
     #[Flow\InjectConfiguration('contentDimensions', 'Neos.ContentRepository')]
     protected array $contentDimensionsConfiguration = [];
+
+    #[Flow\Inject]
+    protected ContextFactoryInterface $contextFactory;
 
     private array $accessibleWorkspaces = [];
 
@@ -300,12 +304,20 @@ final class UsageDetailsService
             $serverRequest = $serverRequest->withUri(new Uri((string)$domain));
         }
 
-        $request = ActionRequest::fromHttpRequest($serverRequest);//$this->getActionRequestForUriBuilder($domain ? $domain->getHostname() : null);
+        // Instead of the live workspace uri we want to link to the user workspace for editing
+        if ($node->getWorkspace()->getBaseWorkspace() === null) {
+            $userWorkspaceContextProperties = [
+                'workspaceName' => $this->userService->getPersonalWorkspaceName(),
+            ];
+            $userWorkspaceContext = $this->contextFactory->create(array_merge($node->getContext()->getProperties(), $userWorkspaceContextProperties));
+            $node = $userWorkspaceContext->getNodeByIdentifier($node->getIdentifier());
+        }
+
+        $request = ActionRequest::fromHttpRequest($serverRequest);
 
         $uriBuilder = new UriBuilder();
         $uriBuilder->setRequest($request);
         $uriBuilder->setCreateAbsoluteUri(false);
-
         $requestUri = $serverRequest->getUri();
         $relativeNodeBackendUri = $uriBuilder->uriFor(
             'index',


### PR DESCRIPTION
Fixes #253 

**What I did**
If the node is in the live workspace, the usage list should link to the user workspace instead of the live workspace.

**How I did it**
If node is in live workspace, I am now loading the node url in the context of the user workspace. 

**How to verify it**
Show usage for image that is in the live workspace and click on it 


<img width="986" height="906" alt="Bildschirmfoto 2026-04-13 um 15 56 27" src="https://github.com/user-attachments/assets/7913ab53-54c7-4810-af48-6c379370a0c5" />
