### PR TITLE
BUGFIX: Replace retry error handler

### DIFF
--- a/packages/core/typings/global.d.ts
+++ b/packages/core/typings/global.d.ts
@@ -10,7 +10,7 @@ interface NeosI18n {
         fallback: string,
         packageKey: string,
         source: string,
-        args: Record<string, unknown> | string[]
+        args: Record<string, unknown> | (string | number)[]
     ) => string;
     initialized: boolean;
 }

--- a/packages/media-module/src/core/CreateErrorHandler.ts
+++ b/packages/media-module/src/core/CreateErrorHandler.ts
@@ -5,7 +5,16 @@ const createErrorHandler = (notify: NeosNotification) => {
         return window.NeosCMS.I18n.translate(id, value, packageKey, source, args);
     };
 
-    return onError(({ graphQLErrors, networkError }) => {
+    return onError(({ graphQLErrors, networkError, operation }) => {
+        const context = operation.getContext();
+        const isRetrying = context.isRetrying;
+
+        // Don't show notifications while retrying - only after max retries exhausted
+        if (isRetrying) {
+            console.warn('[ErrorHandler] Suppressing error notifications during retry attempts');
+            return;
+        }
+
         if (graphQLErrors) {
             graphQLErrors.map((data) => {
                 const isInternalError = data.extensions?.category === 'internal';
@@ -17,7 +26,11 @@ const createErrorHandler = (notify: NeosNotification) => {
                 if (data.extensions?.errorCode) {
                     errorTitleLabel = `errors.${data.extensions.errorCode}.title`;
                     errorMessageLabel = `errors.${data.extensions.errorCode}.message`;
+                } else if (data.extensions?.debugMessage) {
+                    errorMessageLabel = data.extensions.debugMessage;
                 }
+
+                console.error('[GraphQL error]:', data);
 
                 notify.error(
                     translate(errorTitleLabel, defaultErrorTitle),
@@ -27,9 +40,11 @@ const createErrorHandler = (notify: NeosNotification) => {
         }
 
         if (networkError) {
-            console.error(`[Network error]: ${networkError}`);
+            console.error('[Network error]:', networkError);
             notify.warning('Network error', 'Please check your connection.');
         }
+
+        // TODO: Show error overlay and ask the user on how to continue (retry, reload, re-login)
     });
 };
 

--- a/packages/media-module/src/core/CreateRetryHandler.ts
+++ b/packages/media-module/src/core/CreateRetryHandler.ts
@@ -1,21 +1,94 @@
-import { RetryLink } from '@apollo/client/link/retry';
+import { ApolloLink, FetchResult, Observable, Operation } from '@apollo/client';
+import { ServerError } from '@apollo/client/link/utils';
 
+const maxRetries = 2;
+const initialDelay = 300;
+
+const isRetryableError = (statusCode: number | undefined): boolean => {
+    if (!statusCode) return false;
+    // Retry on 401 (auth errors) or 5xx (server errors)
+    return statusCode === 401 || (statusCode >= 500 && statusCode < 600);
+};
+
+/**
+ * Custom retry link that handles GraphQL errors with statusCode in extensions.
+ * Unlike the standard RetryLink, this can retry based on GraphQL error status codes,
+ * not just HTTP status codes (which are always 200 for GraphQL).
+ *
+ * Retries on:
+ * - 401 (Authentication errors - might be temporary token refresh issues)
+ * - 5xx (Server errors)
+ */
 const createRetryHandler = () => {
-    return new RetryLink({
-        delay: {
-            initial: 300,
-            max: Infinity,
-            jitter: true,
-        },
-        attempts: {
-            max: 2,
-            retryIf: (error, _operation) => {
-                if ((error && error.statusCode < 500) || error.statusCode >= 600) {
-                    console.warn('Retrying request due to error:', [error.name, error.statusCode]);
+    return new ApolloLink((operation: Operation, forward) => {
+        return new Observable((observer) => {
+            let retryCount = 0;
+
+            // Set retry flag from the start to suppress error notifications until we're done retrying
+            operation.setContext({
+                isRetrying: true,
+            });
+
+            const attemptRequest = () => {
+                // Clear retry flag if this is the last attempt
+                if (retryCount >= maxRetries) {
+                    operation.setContext({
+                        isRetrying: false,
+                    });
                 }
-                return false;
-            },
-        },
+
+                const subscription = forward(operation).subscribe({
+                    next: (result: FetchResult) => {
+                        // Check if there are GraphQL errors with retryable status codes
+                        const retryableError = result.errors?.find((error) =>
+                            isRetryableError(error.extensions?.statusCode as number)
+                        );
+
+                        if (retryableError && retryCount < maxRetries) {
+                            retryCount++;
+
+                            // Will retry - set context flag to suppress error notifications
+                            operation.setContext({
+                                isRetrying: true,
+                                retryAttempt: retryCount,
+                            });
+
+                            const delay = initialDelay * Math.pow(2, retryCount - 1);
+                            const jitter = Math.random() * 100;
+
+                            // Retry after delay - DON'T pass result to observer yet
+                            setTimeout(() => {
+                                subscription.unsubscribe();
+                                attemptRequest();
+                            }, delay + jitter);
+                        } else {
+                            // Max retries reached or no retryable error - pass result through
+                            observer.next(result);
+                            observer.complete();
+                        }
+                    },
+                    error: (error: ServerError) => {
+                        // Handle network errors
+                        if (isRetryableError(error.statusCode) && retryCount < maxRetries) {
+                            retryCount++;
+                            const delay = initialDelay * Math.pow(2, retryCount - 1);
+                            const jitter = Math.random() * 100;
+
+                            setTimeout(attemptRequest, delay + jitter);
+                        } else {
+                            // Max retries reached or non-retryable error
+                            observer.error(error);
+                        }
+                    },
+                    complete: () => {
+                        // This shouldn't happen with next() being called, but handle it
+                        observer.complete();
+                    },
+                });
+            };
+
+            attemptRequest();
+        });
     });
 };
 

--- a/packages/media-module/src/index.tsx
+++ b/packages/media-module/src/index.tsx
@@ -46,8 +46,8 @@ window.onload = async (): Promise<void> => {
         connectToDevTools: true,
         cache,
         link: ApolloLink.from([
-            createErrorHandler(Notification),
-            createRetryHandler(),
+            createRetryHandler(), // Retry first, BEFORE showing errors
+            createErrorHandler(Notification), // Then handle errors (only shown after retries exhausted)
             createUploadLink({
                 uri: endpoints.graphql,
                 credentials: 'same-origin',

--- a/packages/media-module/src/index.tsx
+++ b/packages/media-module/src/index.tsx
@@ -38,7 +38,13 @@ window.onload = async (): Promise<void> => {
 
     const { Notification } = window.NeosCMS;
 
-    const translate = (id, value = null, args = {}, packageKey = 'Flowpack.Media.Ui', source = 'Main') => {
+    const translate: TranslateFunction = (
+        id,
+        value = null,
+        args = {},
+        packageKey = 'Flowpack.Media.Ui',
+        source = 'Main'
+    ) => {
         return window.NeosCMS.I18n.translate(id, value, packageKey, source, args);
     };
 

--- a/packages/media-module/tests/tags.ts
+++ b/packages/media-module/tests/tags.ts
@@ -1,4 +1,3 @@
-import { Selector } from 'testcafe';
 import page from './page-model';
 
 fixture('Tags').page('./?reset=1');


### PR DESCRIPTION
The RetryLink didn’t properly handle the encapsulated errors in the graphql responses. With our custom handler we can handle the actual error and decided how and when to show a notification to the user.

Relates: [#90](https://github.com/Flowpack/media-ui/issues/90)