### PR TITLE
TASK: Use immutable yarn installs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn
+        run: yarn --immutable
 
       - name: Run linting
         run: yarn lint
@@ -132,7 +132,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn
+        run: yarn --immutable
 
       - name: Run mocha tests
         run: yarn test:unit
@@ -151,7 +151,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn
+        run: yarn --immutable
 
       - name: Build main module
         run: yarn build:module


### PR DESCRIPTION
`--immutable` makes the install fail if `yarn.lock` would be modified.

This change introduces `-immutable` to make builds more reproducible.