### PR TITLE
TASK: Require an asset source for all operations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
         uses: php-actions/phpstan@v3
         with:
           php_version: ${{ matrix.php-versions }}
-          configuration: phpstan.neon
+          configuration: phpstan.ci.neon
 
   php-unit-tests:
     env:

--- a/Classes/Command/AssetCollectionsCommandController.php
+++ b/Classes/Command/AssetCollectionsCommandController.php
@@ -24,29 +24,18 @@ use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
 
-/**
- * @Flow\Scope("singleton")
- */
+#[Flow\Scope('singleton')]
 class AssetCollectionsCommandController extends CommandController
 {
 
-    /**
-     * @Flow\Inject
-     * @var AssetCollectionRepository
-     */
-    protected $assetCollectionRepository;
+    #[Flow\Inject]
+    protected AssetCollectionRepository $assetCollectionRepository;
 
-    /**
-     * @Flow\Inject
-     * @var PersistenceManagerInterface
-     */
-    protected $persistenceManager;
+    #[Flow\Inject]
+    protected PersistenceManagerInterface $persistenceManager;
 
-    /**
-     * @Flow\Inject
-     * @var AssetCollectionService
-     */
-    protected $assetCollectionService;
+    #[Flow\Inject]
+    protected AssetCollectionService $assetCollectionService;
 
     public function hierarchyCommand(): void
     {
@@ -56,12 +45,18 @@ class AssetCollectionsCommandController extends CommandController
             return [
                 $this->persistenceManager->getIdentifierByObject($assetCollection),
                 $assetCollection->getTitle(),
-                $assetCollection->getParent() ? $this->persistenceManager->getIdentifierByObject($assetCollection->getParent()) : 'None',
+                $assetCollection->getParent() ? $this->persistenceManager->getIdentifierByObject(
+                    $assetCollection->getParent()
+                ) : 'None',
                 $assetCollection->getParent() ? $assetCollection->getParent()->getTitle() : 'None',
-                implode(', ',
-                    array_map(static fn(AssetCollection $assetCollection) => $assetCollection->getTitle(), $children)),
-                implode("\n",
-                    array_map(static fn(Tag $tag) => $tag->getLabel(), $assetCollection->getTags()->toArray())),
+                implode(
+                    ', ',
+                    array_map(static fn(AssetCollection $assetCollection) => $assetCollection->getTitle(), $children)
+                ),
+                implode(
+                    "\n",
+                    array_map(static fn(Tag $tag) => $tag->getLabel(), $assetCollection->getTags()->toArray())
+                ),
                 $assetCollection->getPath(),
             ];
         }, $this->assetCollectionRepository->findAll()->toArray());

--- a/Classes/GraphQL/Context/AssetSourceContext.php
+++ b/Classes/GraphQL/Context/AssetSourceContext.php
@@ -207,17 +207,17 @@ class AssetSourceContext
             return null;
         }
 
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $newAssetCollection */
         $newAssetCollection = new AssetCollection($title->value);
         if ($parent) {
             $parentCollection = $this->assetCollectionRepository->findByIdentifier($parent->value);
-            /** @var HierarchicalAssetCollectionInterface&AssetCollection $newAssetCollection */
             $newAssetCollection->setParent($parentCollection);
         }
 
         // FIXME: Multiple asset collections with the same title can exist, but do we want that?
         $this->assetCollectionRepository->add($newAssetCollection);
         return Types\AssetCollection::create(
-            $this->persistenceManager->getIdentifierByObject($newAssetCollection),
+            Types\AssetCollectionId::fromString($this->persistenceManager->getIdentifierByObject($newAssetCollection)),
             $assetSourceId,
             Types\AssetCollectionTitle::fromString($newAssetCollection->getTitle()),
             Types\AssetCollectionPath::fromString($newAssetCollection->getPath()),

--- a/Classes/GraphQL/Context/AssetSourceContext.php
+++ b/Classes/GraphQL/Context/AssetSourceContext.php
@@ -210,7 +210,7 @@ class AssetSourceContext
         $newAssetCollection = new AssetCollection($title->value);
         if ($parent) {
             $parentCollection = $this->assetCollectionRepository->findByIdentifier($parent->value);
-            /** @var HierarchicalAssetCollectionInterface $newAssetCollection */
+            /** @var HierarchicalAssetCollectionInterface&AssetCollection $newAssetCollection */
             $newAssetCollection->setParent($parentCollection);
         }
 

--- a/Classes/GraphQL/Context/AssetSourceContext.php
+++ b/Classes/GraphQL/Context/AssetSourceContext.php
@@ -14,16 +14,28 @@ namespace Flowpack\Media\Ui\GraphQL\Context;
  * source code.
  */
 
+use Flowpack\Media\Ui\Domain\Model\HierarchicalAssetCollectionInterface;
+use Flowpack\Media\Ui\Exception as MediaUiException;
 use Flowpack\Media\Ui\GraphQL\Types;
+use Flowpack\Media\Ui\GraphQL\Types\TagLabel;
+use Flowpack\Media\Ui\Service\UsageDetailsService;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Media\Domain\Model\Asset;
+use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
+use Neos\Media\Domain\Model\Tag;
+use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Media\Domain\Repository\AssetRepository;
+use Neos\Media\Domain\Repository\TagRepository;
 use Neos\Media\Domain\Service\AssetSourceService;
 use Neos\Media\Exception\AssetSourceServiceException;
 
+/**
+ * This class is the translation layer between the Media.Ui API and the capabilities of the asset sources
+ */
 class AssetSourceContext
 {
     /**
@@ -42,6 +54,9 @@ class AssetSourceContext
         protected readonly PersistenceManagerInterface $persistenceManager,
         protected readonly AssetSourceService $assetSourceService,
         protected readonly AssetRepository $assetRepository,
+        protected readonly AssetCollectionRepository $assetCollectionRepository,
+        protected readonly TagRepository $tagRepository,
+        protected readonly UsageDetailsService $usageDetailsService,
     ) {
         $this->assetSources = $this->assetSourceService->getAssetSources();
     }
@@ -107,5 +122,119 @@ class AssetSourceContext
         } catch (AssetSourceServiceException|\Exception $e) {
         }
         return null;
+    }
+
+    public function getAssetCollections(?Types\AssetSourceId $assetSourceId): Types\AssetCollections
+    {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only know about collections in the neos asset source
+            return Types\AssetCollections::empty();
+        }
+
+        return Types\AssetCollections::fromArray(
+            array_map(
+                fn(HierarchicalAssetCollectionInterface $assetCollection) => Types\AssetCollection::create(
+                    Types\AssetCollectionId::fromString(
+                        $this->persistenceManager->getIdentifierByObject($assetCollection)
+                    ),
+                    $assetSourceId,
+                    Types\AssetCollectionTitle::fromString($assetCollection->getTitle()),
+                    Types\AssetCollectionPath::fromString($assetCollection->getPath()),
+                ),
+                $this->assetCollectionRepository->findAll()->toArray()
+            )
+        );
+    }
+
+    public function getAssetCollection(
+        Types\AssetCollectionId $id,
+        Types\AssetSourceId $assetSourceId
+    ): ?Types\AssetCollection {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only know about collections in the neos asset source
+            return null;
+        }
+        /** @var HierarchicalAssetCollectionInterface $assetCollection */
+        $assetCollection = $this->assetCollectionRepository->findByIdentifier($id->value);
+        return $assetCollection ? Types\AssetCollection::create(
+            $id,
+            $assetSourceId,
+            Types\AssetCollectionTitle::fromString($assetCollection->getTitle()),
+            Types\AssetCollectionPath::fromString($assetCollection->getPath()),
+        ) : null;
+    }
+
+    public function getTags(?Types\AssetSourceId $assetSourceId): Types\Tags
+    {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only know about tags in the neos asset source
+            return Types\Tags::empty();
+        }
+
+        return Types\Tags::fromArray(
+            array_map(
+                fn(Tag $tag) => Types\Tag::create(
+                    Types\TagId::fromString($this->persistenceManager->getIdentifierByObject($tag)),
+                    $assetSourceId,
+                    TagLabel::fromString($tag->getLabel()),
+                ),
+                $this->tagRepository->findAll()->toArray()
+            )
+        );
+    }
+
+    public function getTag(Types\TagId $id, Types\AssetSourceId $assetSourceId): ?Types\Tag
+    {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only support creating collections in the neos asset source
+            return null;
+        }
+        /** @var Tag $tag */
+        $tag = $this->tagRepository->findByIdentifier($id->value);
+        return $tag ? Types\Tag::create($id, $assetSourceId, TagLabel::fromString($tag->getLabel())) : null;
+    }
+
+    /**
+     * @throws IllegalObjectTypeException
+     */
+    public function createAssetCollection(
+        Types\AssetCollectionTitle $title,
+        Types\AssetSourceId $assetSourceId,
+        ?Types\AssetCollectionId $parent
+    ): ?Types\AssetCollection {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only support creating collections in the neos asset source
+            return null;
+        }
+
+        $newAssetCollection = new AssetCollection($title->value);
+        if ($parent) {
+            $parentCollection = $this->assetCollectionRepository->findByIdentifier($parent->value);
+            /** @var HierarchicalAssetCollectionInterface $newAssetCollection */
+            $newAssetCollection->setParent($parentCollection);
+        }
+
+        // FIXME: Multiple asset collections with the same title can exist, but do we want that?
+        $this->assetCollectionRepository->add($newAssetCollection);
+        return Types\AssetCollection::create(
+            $this->persistenceManager->getIdentifierByObject($newAssetCollection),
+            $assetSourceId,
+            Types\AssetCollectionTitle::fromString($newAssetCollection->getTitle()),
+            Types\AssetCollectionPath::fromString($newAssetCollection->getPath()),
+        );
+    }
+
+    /**
+     * @throws MediaUiException
+     */
+    public function getUnusedAssets(Types\AssetSourceId $assetSourceId, int $limit, int $offset): Types\Assets
+    {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only support creating collections in the neos asset source
+            return Types\Assets::empty();
+        }
+
+        $assets = $this->usageDetailsService->getUnusedAssets($limit, $offset, Types\AssetSourceId::default());
+        return Types\Assets::fromAssets($assets);
     }
 }

--- a/Classes/GraphQL/MediaApi.php
+++ b/Classes/GraphQL/MediaApi.php
@@ -77,12 +77,12 @@ final class MediaApi
      */
     #[Query]
     public function assetCount(
-        Types\AssetSourceId $assetSourceId = null,
-        Types\AssetCollectionId $assetCollectionId = null,
-        Types\MediaType $mediaType = null,
-        Types\AssetType $assetType = null,
-        Types\TagId $tagId = null,
-        string $searchTerm = null,
+        Types\AssetSourceId $assetSourceId,
+        ?Types\AssetCollectionId $assetCollectionId = null,
+        ?Types\MediaType $mediaType = null,
+        ?Types\AssetType $assetType = null,
+        ?Types\TagId $tagId = null,
+        ?string $searchTerm = null,
     ): int {
         $iterator = $this->assetProxyIteratorBuilder->build(
             $assetSourceId,
@@ -103,14 +103,14 @@ final class MediaApi
     #[Description('Provides a filterable list of asset proxies. These are the main entities for media management.')]
     #[Query]
     public function assets(
-        Types\AssetSourceId $assetSourceId = null,
-        Types\AssetCollectionId $assetCollectionId = null,
-        Types\MediaType $mediaType = null,
-        Types\AssetType $assetType = null,
-        Types\TagId $tagId = null,
-        Types\SortBy $sortBy = null,
-        Types\SortDirection $sortDirection = null,
-        string $searchTerm = null,
+        Types\AssetSourceId $assetSourceId,
+        ?Types\AssetCollectionId $assetCollectionId = null,
+        ?Types\MediaType $mediaType = null,
+        ?Types\AssetType $assetType = null,
+        ?Types\TagId $tagId = null,
+        ?Types\SortBy $sortBy = null,
+        ?Types\SortDirection $sortDirection = null,
+        ?string $searchTerm = null,
         int $limit = 20,
         int $offset = 0,
     ): ?Types\Assets {
@@ -137,7 +137,7 @@ final class MediaApi
 
     #[Description('All asset collections')]
     #[Query]
-    public function assetCollections(Types\AssetSourceId $assetSourceId = null): Types\AssetCollections
+    public function assetCollections(Types\AssetSourceId $assetSourceId): Types\AssetCollections
     {
         return $this->assetSourceContext->getAssetCollections($assetSourceId);
     }
@@ -159,29 +159,29 @@ final class MediaApi
      */
     #[Description('Provides number of unused assets in local asset source')]
     #[Query]
-    public function unusedAssetCount(Types\AssetSourceId $assetSourceId = null): int
+    public function unusedAssetCount(Types\AssetSourceId $assetSourceId): int
     {
         return $this->usageDetailsService->getUnusedAssetCount($assetSourceId);
     }
 
     #[Description('Provides a list of all tags')]
     #[Query]
-    public function tags(Types\AssetSourceId $assetSourceId = null): Types\Tags
+    public function tags(Types\AssetSourceId $assetSourceId): Types\Tags
     {
         return $this->assetSourceContext->getTags($assetSourceId);
     }
 
     #[Description('Get tag by id')]
     #[Query]
-    public function tag(?Types\TagId $id, Types\AssetSourceId $assetSourceId = null): ?Types\Tag
+    public function tag(Types\TagId $id, Types\AssetSourceId $assetSourceId): ?Types\Tag
     {
-        return $id ? $this->assetSourceContext->getTag($id, $assetSourceId) : null;
+        return $this->assetSourceContext->getTag($id, $assetSourceId);
     }
 
     #[Description('Returns an asset collection by id')]
     #[Query]
     public function assetCollection(
-        ?Types\AssetCollectionId $id,
+        Types\AssetCollectionId $id,
         Types\AssetSourceId $assetSourceId
     ): ?Types\AssetCollection {
         return $id ? $this->assetSourceContext->getAssetCollection($id, $assetSourceId) : null;
@@ -270,7 +270,7 @@ final class MediaApi
 
     #[Description('Provides a list of changes to assets since a given timestamp')]
     #[Query]
-    public function changedAssets(Types\DateTime $since = null): Types\ChangedAssetsResult
+    public function changedAssets(?Types\DateTime $since = null): Types\ChangedAssetsResult
     {
         $changes = $this->assetChangeLog->getChanges($since);
         return instantiate(Types\ChangedAssetsResult::class, [
@@ -475,16 +475,16 @@ final class MediaApi
      */
     #[Mutation]
     public function uploadFile(
-        Types\UploadedFile $file = null,
-        Types\TagId $tagId = null,
-        Types\AssetCollectionId $assetCollectionId = null,
-        Types\AssetSourceId $assetSourceId = null,
+        Types\UploadedFile $file,
+        Types\AssetSourceId $assetSourceId,
+        ?Types\TagId $tagId = null,
+        ?Types\AssetCollectionId $assetCollectionId = null,
     ): Types\FileUploadResult {
         return $this->assetMutator->uploadFile(
             $file,
+            $assetSourceId,
             $tagId,
             $assetCollectionId,
-            $assetSourceId,
         );
     }
 
@@ -493,16 +493,16 @@ final class MediaApi
      */
     #[Mutation]
     public function uploadFiles(
-        Types\UploadedFiles $files = null,
-        Types\TagId $tagId = null,
-        Types\AssetCollectionId $assetCollectionId = null,
-        Types\AssetSourceId $assetSourceId = null,
+        Types\UploadedFiles $files,
+        Types\AssetSourceId $assetSourceId,
+        ?Types\TagId $tagId = null,
+        ?Types\AssetCollectionId $assetCollectionId = null,
     ): Types\FileUploadResults {
         return $this->assetMutator->uploadFiles(
             $files,
+            $assetSourceId,
             $tagId,
             $assetCollectionId,
-            $assetSourceId,
         );
     }
 

--- a/Classes/GraphQL/MediaApi.php
+++ b/Classes/GraphQL/MediaApi.php
@@ -14,7 +14,8 @@ namespace Flowpack\Media\Ui\GraphQL;
  * source code.
  */
 
-use Flowpack\Media\Ui\Domain\Model\HierarchicalAssetCollectionInterface;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
 use Flowpack\Media\Ui\Domain\Model\SearchTerm;
 use Flowpack\Media\Ui\Exception;
 use Flowpack\Media\Ui\Exception as MediaUiException;
@@ -30,16 +31,14 @@ use Flowpack\Media\Ui\Service\SimilarityService;
 use Flowpack\Media\Ui\Service\UsageDetailsService;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
+use Neos\Flow\Persistence\Exception\InvalidQueryException;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\ResourceManagement\Exception as ResourceManagementException;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
 use Neos\Media\Domain\Model\AssetSource\Neos\NeosAssetProxy;
 use Neos\Media\Domain\Model\AssetVariantInterface;
-use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Model\VariantSupportInterface;
-use Neos\Media\Domain\Repository\AssetCollectionRepository;
-use Neos\Media\Domain\Repository\TagRepository;
 use Neos\Media\Domain\Service\AssetService;
 use Neos\Utility\Exception\FilesException;
 use Neos\Utility\Files;
@@ -58,7 +57,6 @@ final class MediaApi
 
     public function __construct(
         private readonly AssetChangeLog $assetChangeLog,
-        private readonly AssetCollectionRepository $assetCollectionRepository,
         private readonly AssetCollectionService $assetCollectionService,
         private readonly AssetCollectionMutator $assetCollectionMutator,
         private readonly AssetMutator $assetMutator,
@@ -70,7 +68,6 @@ final class MediaApi
         private readonly PrivilegeManagerInterface $privilegeManager,
         private readonly SimilarityService $similarityService,
         private readonly TagMutator $tagMutator,
-        private readonly TagRepository $tagRepository,
         private readonly UsageDetailsService $usageDetailsService,
     ) {
     }
@@ -140,75 +137,54 @@ final class MediaApi
 
     #[Description('All asset collections')]
     #[Query]
-    public function assetCollections(): Types\AssetCollections
+    public function assetCollections(Types\AssetSourceId $assetSourceId = null): Types\AssetCollections
     {
-        return Types\AssetCollections::fromArray(
-            array_map(
-                fn(HierarchicalAssetCollectionInterface $assetCollection) => instantiate(Types\AssetCollection::class, [
-                    'id' => $this->persistenceManager->getIdentifierByObject($assetCollection),
-                    'title' => $assetCollection->getTitle(),
-                    'path' => $assetCollection->getPath(),
-                ]), $this->assetCollectionRepository->findAll()->toArray()
-            )
-        );
+        return $this->assetSourceContext->getAssetCollections($assetSourceId);
     }
 
     #[Description('All configured asset sources (by default only the "neos" source)')]
     #[Query]
     public function assetSources(): Types\AssetSources
     {
-        return Types\AssetSources::fromArray(array_map(
+        return Types\AssetSources::fromArray(
+            array_map(
                 static fn(AssetSourceInterface $assetSource) => Types\AssetSource::fromAssetSource($assetSource),
-                $this->assetSourceContext->getAssetSources())
+                $this->assetSourceContext->getAssetSources()
+            )
         );
     }
 
     /**
-     * @throws MediaUiException
+     * @throws NonUniqueResultException|MediaUiException|NoResultException
      */
     #[Description('Provides number of unused assets in local asset source')]
     #[Query]
-    public function unusedAssetCount(): int
+    public function unusedAssetCount(Types\AssetSourceId $assetSourceId = null): int
     {
-        return $this->usageDetailsService->getUnusedAssetCount();
+        return $this->usageDetailsService->getUnusedAssetCount($assetSourceId);
     }
 
     #[Description('Provides a list of all tags')]
     #[Query]
-    public function tags(): Types\Tags
+    public function tags(Types\AssetSourceId $assetSourceId = null): Types\Tags
     {
-        return Types\Tags::fromArray(array_map(
-            fn(Tag $tag) => instantiate(Types\Tag::class, [
-                'id' => $this->persistenceManager->getIdentifierByObject($tag),
-                'label' => $tag->getLabel(),
-            ]),
-            $this->tagRepository->findAll()->toArray()
-        ));
+        return $this->assetSourceContext->getTags($assetSourceId);
     }
 
     #[Description('Get tag by id')]
     #[Query]
-    public function tag(?Types\TagId $id): ?Types\Tag
+    public function tag(?Types\TagId $id, Types\AssetSourceId $assetSourceId = null): ?Types\Tag
     {
-        /** @var Tag $tag */
-        $tag = $id ? $this->tagRepository->findByIdentifier($id->value) : null;
-        return $tag ? instantiate(Types\Tag::class, [
-            'id' => $id,
-            'label' => $tag->getLabel(),
-        ]) : null;
+        return $id ? $this->assetSourceContext->getTag($id, $assetSourceId) : null;
     }
 
     #[Description('Returns an asset collection by id')]
     #[Query]
-    public function assetCollection(?Types\AssetCollectionId $id): ?Types\AssetCollection
-    {
-        /** @var HierarchicalAssetCollectionInterface $assetCollection */
-        $assetCollection = $id ? $this->assetCollectionRepository->findByIdentifier($id->value) : null;
-        return $assetCollection ? instantiate(Types\AssetCollection::class, [
-            'id' => $id,
-            'title' => $assetCollection->getTitle(),
-            'path' => $assetCollection->getPath(),
-        ]) : null;
+    public function assetCollection(
+        ?Types\AssetCollectionId $id,
+        Types\AssetSourceId $assetSourceId
+    ): ?Types\AssetCollection {
+        return $id ? $this->assetSourceContext->getAssetCollection($id, $assetSourceId) : null;
     }
 
     #[Description('Returns an asset by id')]
@@ -229,9 +205,13 @@ final class MediaApi
             'uploadMaxFileSize' => $this->getMaximumFileUploadSize(),
             'uploadMaxFileUploadLimit' => $this->getMaximumFileUploadLimit(),
             'currentServerTime' => Types\DateTime::now(),
-            'defaultAssetCollectionId' => $defaultAssetCollection ? $this->persistenceManager->getIdentifierByObject($defaultAssetCollection) : null,
+            'defaultAssetCollectionId' => $defaultAssetCollection ? $this->persistenceManager->getIdentifierByObject(
+                $defaultAssetCollection
+            ) : null,
             'canManageTags' => $this->privilegeManager->isPrivilegeTargetGranted('Flowpack.Media.Ui:ManageTags'),
-            'canManageAssetCollections' => $this->privilegeManager->isPrivilegeTargetGranted('Flowpack.Media.Ui:ManageAssetCollections'),
+            'canManageAssetCollections' => $this->privilegeManager->isPrivilegeTargetGranted(
+                'Flowpack.Media.Ui:ManageAssetCollections'
+            ),
             'canManageAssets' => $this->privilegeManager->isPrivilegeTargetGranted('Flowpack.Media.Ui:ManageAssets'),
         ]);
     }
@@ -278,15 +258,14 @@ final class MediaApi
 
     #[Description('Provides a list of all unused assets in local asset source')]
     #[Query]
-    public function unusedAssets(int $limit = 20, int $offset = 0): Types\Assets
+    public function unusedAssets(Types\AssetSourceId $assetSourceId, int $limit = 20, int $offset = 0): Types\Assets
     {
-        $assets = [];
         try {
-            $assets = $this->usageDetailsService->getUnusedAssets($limit, $offset, Types\AssetSourceId::default());
+            return $this->assetSourceContext->getUnusedAssets($assetSourceId, $limit, $offset);
         } catch (MediaUiException $e) {
             $this->logger->error('Could not retrieve unused assets', ['exception' => $e]);
         }
-        return Types\Assets::fromAssets($assets);
+        return Types\Assets::empty();
     }
 
     #[Description('Provides a list of changes to assets since a given timestamp')]
@@ -401,10 +380,12 @@ final class MediaApi
     #[Mutation]
     public function createAssetCollection(
         Types\AssetCollectionTitle $title,
+        Types\AssetSourceId $assetSourceId,
         ?Types\AssetCollectionId $parent = null,
     ): ?Types\AssetCollection {
         return $this->assetCollectionMutator->createAssetCollection(
             $title,
+            $assetSourceId,
             $parent,
         );
     }
@@ -416,8 +397,9 @@ final class MediaApi
     #[Mutation]
     public function deleteAssetCollection(
         Types\AssetCollectionId $id,
+        Types\AssetSourceId $assetSourceId,
     ): MutationResult {
-        return $this->assetCollectionMutator->deleteAssetCollection($id);
+        return $this->assetCollectionMutator->deleteAssetCollection($id, $assetSourceId);
     }
 
     /**
@@ -427,10 +409,11 @@ final class MediaApi
     #[Mutation]
     public function updateAssetCollection(
         Types\AssetCollectionId $id,
+        Types\AssetSourceId $assetSourceId,
         ?Types\AssetCollectionTitle $title = null,
         ?Types\TagIds $tagIds = null,
     ): MutationResult {
-        return $this->assetCollectionMutator->updateAssetCollection($id, $title, $tagIds);
+        return $this->assetCollectionMutator->updateAssetCollection($id, $assetSourceId, $title, $tagIds);
     }
 
     /**
@@ -439,9 +422,10 @@ final class MediaApi
     #[Mutation]
     public function setAssetCollectionParent(
         Types\AssetCollectionId $id,
+        Types\AssetSourceId $assetSourceId,
         ?Types\AssetCollectionId $parent = null,
     ): MutationResult {
-        return $this->assetCollectionMutator->setAssetCollectionParent($id, $parent);
+        return $this->assetCollectionMutator->setAssetCollectionParent($id, $assetSourceId, $parent);
     }
 
     /**
@@ -493,12 +477,14 @@ final class MediaApi
     public function uploadFile(
         Types\UploadedFile $file = null,
         Types\TagId $tagId = null,
-        Types\AssetCollectionId $assetCollectionId = null
+        Types\AssetCollectionId $assetCollectionId = null,
+        Types\AssetSourceId $assetSourceId = null,
     ): Types\FileUploadResult {
         return $this->assetMutator->uploadFile(
             $file,
             $tagId,
-            $assetCollectionId
+            $assetCollectionId,
+            $assetSourceId,
         );
     }
 
@@ -509,12 +495,14 @@ final class MediaApi
     public function uploadFiles(
         Types\UploadedFiles $files = null,
         Types\TagId $tagId = null,
-        Types\AssetCollectionId $assetCollectionId = null
+        Types\AssetCollectionId $assetCollectionId = null,
+        Types\AssetSourceId $assetSourceId = null,
     ): Types\FileUploadResults {
         return $this->assetMutator->uploadFiles(
             $files,
             $tagId,
-            $assetCollectionId
+            $assetCollectionId,
+            $assetSourceId,
         );
     }
 
@@ -522,26 +510,32 @@ final class MediaApi
      * @throws Exception|IllegalObjectTypeException
      */
     #[Mutation]
-    public function createTag(Types\TagLabel $label, Types\AssetCollectionId $assetCollectionId = null): Types\Tag
-    {
-        return $this->tagMutator->createTag($label, $assetCollectionId);
+    public function createTag(
+        Types\TagLabel $label,
+        Types\AssetSourceId $assetSourceId,
+        Types\AssetCollectionId $assetCollectionId = null
+    ): Types\Tag {
+        return $this->tagMutator->createTag($label, $assetSourceId, $assetCollectionId);
     }
 
     /**
      * @throws Exception|IllegalObjectTypeException
      */
     #[Mutation]
-    public function updateTag(Types\TagId $id, Types\TagLabel $label = null): Types\Tag
-    {
-        return $this->tagMutator->updateTag($id, $label);
+    public function updateTag(
+        Types\TagId $id,
+        Types\AssetSourceId $assetSourceId,
+        Types\TagLabel $label = null
+    ): Types\Tag {
+        return $this->tagMutator->updateTag($id, $assetSourceId, $label);
     }
 
     /**
-     * @throws Exception|IllegalObjectTypeException
+     * @throws Exception|IllegalObjectTypeException|InvalidQueryException
      */
     #[Mutation]
-    public function deleteTag(Types\TagId $id): MutationResult
+    public function deleteTag(Types\TagId $id, Types\AssetSourceId $assetSourceId): MutationResult
     {
-        return $this->tagMutator->deleteTag($id);
+        return $this->tagMutator->deleteTag($id, $assetSourceId);
     }
 }

--- a/Classes/GraphQL/Mutator/AssetCollectionMutator.php
+++ b/Classes/GraphQL/Mutator/AssetCollectionMutator.php
@@ -17,19 +17,17 @@ namespace Flowpack\Media\Ui\GraphQL\Mutator;
 use Doctrine\Common\Collections\ArrayCollection;
 use Flowpack\Media\Ui\Domain\Model\HierarchicalAssetCollectionInterface;
 use Flowpack\Media\Ui\Exception;
+use Flowpack\Media\Ui\GraphQL\Context\AssetSourceContext;
 use Flowpack\Media\Ui\GraphQL\Types;
 use Flowpack\Media\Ui\GraphQL\Types\MutationResult;
 use Flowpack\Media\Ui\Service\AssetCollectionService;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\I18n\Translator;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
-use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Media\Domain\Repository\TagRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
-
-use function Wwwision\Types\instantiate;
 
 #[Flow\Scope("singleton")]
 class AssetCollectionMutator
@@ -37,7 +35,7 @@ class AssetCollectionMutator
     public function __construct(
         private readonly AssetCollectionRepository $assetCollectionRepository,
         private readonly AssetCollectionService $assetCollectionService,
-        private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly AssetSourceContext $assetSourceContext,
         private readonly TagRepository $tagRepository,
         private readonly SiteRepository $siteRepository,
         private readonly Translator $translator,
@@ -47,8 +45,14 @@ class AssetCollectionMutator
     protected function localizedMessage(string $id, string $fallback = '', array $arguments = []): string
     {
         try {
-            return $this->translator->translateById($id, $arguments, null, null, 'Main',
-                'Flowpack.Media.Ui') ?? $fallback;
+            return $this->translator->translateById(
+                $id,
+                $arguments,
+                null,
+                null,
+                'Main',
+                'Flowpack.Media.Ui'
+            ) ?? $fallback;
         } catch (\Exception) {
             return $fallback ?: $id;
         }
@@ -59,30 +63,29 @@ class AssetCollectionMutator
      */
     public function createAssetCollection(
         Types\AssetCollectionTitle $title,
+        Types\AssetSourceId $assetSourceId,
         Types\AssetCollectionId $parent = null
     ): Types\AssetCollection {
-        $newAssetCollection = new AssetCollection($title->value);
-        if ($parent) {
-            $parentCollection = $this->assetCollectionRepository->findByIdentifier($parent->value);
-            /** @var HierarchicalAssetCollectionInterface $newAssetCollection */
-            /** @phpstan-ignore varTag.nativeType */
-            $newAssetCollection->setParent($parentCollection);
-        }
-
-        // FIXME: Multiple asset collections with the same title can exist, but do we want that?
-        $this->assetCollectionRepository->add($newAssetCollection);
-        return instantiate(Types\AssetCollection::class, [
-            'id' => $this->persistenceManager->getIdentifierByObject($newAssetCollection),
-            'title' => $newAssetCollection->getTitle(),
-            'path' => $newAssetCollection->getPath(),
-        ]);
+        return $this->assetSourceContext->createAssetCollection($title, $assetSourceId, $parent);
     }
 
     /**
      * @throws Exception|IllegalObjectTypeException
      */
-    public function deleteAssetCollection(Types\AssetCollectionId $id): MutationResult
-    {
+    public function deleteAssetCollection(
+        Types\AssetCollectionId $id,
+        Types\AssetSourceId $assetSourceId,
+    ): MutationResult {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only support managing collections in the neos asset source
+            return MutationResult::fromError([
+                $this->localizedMessage(
+                    'actions.assetSourceNotSupported',
+                    'Asset source not supported'
+                )
+            ]);
+        }
+
         $assetCollection = $this->assetCollectionRepository->findByIdentifier($id->value);
         if (!$assetCollection) {
             return MutationResult::fromError([
@@ -121,9 +124,20 @@ class AssetCollectionMutator
      */
     public function updateAssetCollection(
         Types\AssetCollectionId $id,
+        Types\AssetSourceId $assetSourceId,
         Types\AssetCollectionTitle $title = null,
-        Types\TagIds $tagIds = null
+        Types\TagIds $tagIds = null,
     ): MutationResult {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only support managing collections in the neos asset source
+            return MutationResult::fromError([
+                $this->localizedMessage(
+                    'actions.assetSourceNotSupported',
+                    'Asset source not supported'
+                )
+            ]);
+        }
+
         /** @var AssetCollection&HierarchicalAssetCollectionInterface $assetCollection */
         $assetCollection = $this->assetCollectionRepository->findByIdentifier($id->value);
         if (!$assetCollection) {
@@ -166,8 +180,19 @@ class AssetCollectionMutator
      */
     public function setAssetCollectionParent(
         Types\AssetCollectionId $id,
+        Types\AssetSourceId $assetSourceId,
         Types\AssetCollectionId $parent = null
     ): MutationResult {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only support managing collections in the neos asset source
+            return MutationResult::fromError([
+                $this->localizedMessage(
+                    'actions.assetSourceNotSupported',
+                    'Asset source not supported'
+                )
+            ]);
+        }
+
         /** @var AssetCollection $assetCollection */
         $assetCollection = $this->assetCollectionRepository->findByIdentifier($id->value);
 

--- a/Classes/GraphQL/Mutator/AssetMutator.php
+++ b/Classes/GraphQL/Mutator/AssetMutator.php
@@ -446,17 +446,13 @@ class AssetMutator
      * Stores the given file and returns an array with the result
      */
     public function uploadFile(
-        ?Types\UploadedFile $file,
-        Types\TagId $tagId = null,
-        Types\AssetCollectionId $assetCollectionId = null,
-        Types\AssetSourceId $assetSourceId = null,
+        Types\UploadedFile $file,
+        Types\AssetSourceId $assetSourceId,
+        ?Types\TagId $tagId = null,
+        ?Types\AssetCollectionId $assetCollectionId = null,
     ): Types\FileUploadResult {
         if ($assetSourceId->value !== 'neos') {
             return Types\FileUploadResult::fromError(self::STATE_UNSUPPORTED);
-        }
-
-        if (!$file) {
-            return Types\FileUploadResult::fromError(self::STATE_ERROR);
         }
 
         $filename = $file->clientFilename;
@@ -503,7 +499,7 @@ class AssetMutator
 
                         $this->assetRepository->add($asset);
                         $result = self::STATE_ADDED;
-                        return Types\FileUploadResult::fromSuccess($result, $filename);
+                        return Types\FileUploadResult::fromSuccess($result, Types\Filename::fromString($filename));
                     }
                 } catch (IllegalObjectTypeException $e) {
                     $this->logger->error('Type of uploaded file cannot be stored: ' . $e->getMessage());
@@ -519,21 +515,19 @@ class AssetMutator
      * Stores all given files and returns an array of results for each upload
      */
     public function uploadFiles(
-        Types\UploadedFiles $files = null,
-        Types\TagId $tagId = null,
-        Types\AssetCollectionId $assetCollectionId = null,
-        Types\AssetSourceId $assetSourceId = null,
+        Types\UploadedFiles $files,
+        Types\AssetSourceId $assetSourceId,
+        ?Types\TagId $tagId = null,
+        ?Types\AssetCollectionId $assetCollectionId = null,
     ): Types\FileUploadResults {
         if ($assetSourceId->value !== 'neos') {
             return Types\FileUploadResults::fromArray([Types\FileUploadResult::fromError(self::STATE_UNSUPPORTED)]);
-        }
-        if (!$files) {
-            return Types\FileUploadResults::empty();
         }
         $results = [];
         foreach ($files as $file) {
             $results[$file->clientFilename] = $this->uploadFile(
                 $file,
+                $assetSourceId,
                 $tagId,
                 $assetCollectionId,
             );

--- a/Classes/GraphQL/Mutator/AssetMutator.php
+++ b/Classes/GraphQL/Mutator/AssetMutator.php
@@ -36,16 +36,17 @@ use Neos\Media\Domain\Service\AssetService;
 use Neos\Media\Domain\Strategy\AssetModelMappingStrategyInterface;
 use Neos\Media\Exception\AssetServiceException;
 use Neos\Utility\MediaTypes;
+use PharIo\Manifest\Type;
 use Psr\Log\LoggerInterface;
-
-use function Wwwision\Types\instantiate;
 
 #[Flow\Scope("singleton")]
 class AssetMutator
 {
-    protected const STATE_ADDED = 'ADDED';
-    protected const STATE_EXISTS = 'EXISTS';
-    protected const STATE_ERROR = 'ERROR';
+    protected const string STATE_ADDED = 'ADDED';
+    protected const string STATE_EXISTS = 'EXISTS';
+    protected const string STATE_ERROR = 'ERROR';
+    protected const string STATE_REPLACED = 'REPLACED';
+    protected const string STATE_UNSUPPORTED = 'UNSUPPORTED';
 
     public function __construct(
         private readonly AssetCollectionRepository $assetCollectionRepository,
@@ -315,8 +316,6 @@ class AssetMutator
             throw new MediaUiException('Asset type "' . $asset::class . '" does not support replacing', 1648046186);
         }
 
-        $success = false;
-        $result = self::STATE_ERROR;
         $sourceMediaType = MediaTypes::parseMediaType($asset->getMediaType());
         $replacementMediaType = MediaTypes::parseMediaType($file->clientMediaType);
         $filename = $file->clientFilename;
@@ -333,11 +332,7 @@ class AssetMutator
                     $replacementMediaType['type']
                 )
             );
-            return instantiate(Types\FileUploadResult::class, [
-                'filename' => $filename,
-                'success' => false,
-                'result' => $result,
-            ]);
+            return Types\FileUploadResult::fromError(self::STATE_ERROR);
         }
 
         try {
@@ -360,8 +355,7 @@ class AssetMutator
                     $resource,
                     $options->toArray()
                 );
-                $success = true;
-                $result = 'REPLACED';
+                return Types\FileUploadResult::fromSuccess(self::STATE_REPLACED, $filename);
             } catch (\Exception $e) {
                 $this->logger->error(
                     sprintf(
@@ -373,11 +367,7 @@ class AssetMutator
             }
         }
 
-        return instantiate(Types\FileUploadResult::class, [
-            'filename' => $filename,
-            'success' => $success,
-            'result' => $result,
-        ]);
+        return Types\FileUploadResult::fromError(self::STATE_ERROR);
     }
 
     /**
@@ -458,17 +448,15 @@ class AssetMutator
     public function uploadFile(
         ?Types\UploadedFile $file,
         Types\TagId $tagId = null,
-        Types\AssetCollectionId $assetCollectionId = null
+        Types\AssetCollectionId $assetCollectionId = null,
+        Types\AssetSourceId $assetSourceId = null,
     ): Types\FileUploadResult {
-        $success = false;
-        $result = self::STATE_ERROR;
+        if ($assetSourceId->value !== 'neos') {
+            return Types\FileUploadResult::fromError(self::STATE_UNSUPPORTED);
+        }
 
         if (!$file) {
-            return instantiate(Types\FileUploadResult::class, [
-                'filename' => null,
-                'success' => false,
-                'result' => $result,
-            ]);
+            return Types\FileUploadResult::fromError(self::STATE_ERROR);
         }
 
         $filename = $file->clientFilename;
@@ -486,9 +474,7 @@ class AssetMutator
             $resource->setFilename($filename);
             $resource->setMediaType($file->clientMediaType);
 
-            if ($this->assetRepository->findOneByResourceSha1($resource->getSha1())) {
-                $result = self::STATE_EXISTS;
-            } else {
+            if (!$this->assetRepository->findOneByResourceSha1($resource->getSha1())) {
                 try {
                     $className = $this->mappingStrategy->map($resource);
                     /** @var Asset $asset */
@@ -517,9 +503,7 @@ class AssetMutator
 
                         $this->assetRepository->add($asset);
                         $result = self::STATE_ADDED;
-                        $success = true;
-                    } else {
-                        $result = self::STATE_EXISTS;
+                        return Types\FileUploadResult::fromSuccess($result, $filename);
                     }
                 } catch (IllegalObjectTypeException $e) {
                     $this->logger->error('Type of uploaded file cannot be stored: ' . $e->getMessage());
@@ -528,11 +512,7 @@ class AssetMutator
         }
 
         // FIXME: The filename is not unique enough for multiple uploads, we need an id instead or use the sha1
-        return instantiate(Types\FileUploadResult::class, [
-            'filename' => $filename,
-            'success' => $success,
-            'result' => $result,
-        ]);
+        return Types\FileUploadResult::fromError(self::STATE_EXISTS);
     }
 
     /**
@@ -541,8 +521,12 @@ class AssetMutator
     public function uploadFiles(
         Types\UploadedFiles $files = null,
         Types\TagId $tagId = null,
-        Types\AssetCollectionId $assetCollectionId = null
+        Types\AssetCollectionId $assetCollectionId = null,
+        Types\AssetSourceId $assetSourceId = null,
     ): Types\FileUploadResults {
+        if ($assetSourceId->value !== 'neos') {
+            return Types\FileUploadResults::fromArray([Types\FileUploadResult::fromError(self::STATE_UNSUPPORTED)]);
+        }
         if (!$files) {
             return Types\FileUploadResults::empty();
         }

--- a/Classes/GraphQL/Mutator/TagMutator.php
+++ b/Classes/GraphQL/Mutator/TagMutator.php
@@ -44,8 +44,14 @@ class TagMutator
     protected function localizedMessage(string $id, string $fallback = '', array $arguments = []): string
     {
         try {
-            return $this->translator->translateById($id, $arguments, null, null, 'Main',
-                'Flowpack.Media.Ui') ?? $fallback;
+            return $this->translator->translateById(
+                $id,
+                $arguments,
+                null,
+                null,
+                'Main',
+                'Flowpack.Media.Ui'
+            ) ?? $fallback;
         } catch (\Exception) {
             return $fallback ?: $id;
         }
@@ -54,8 +60,19 @@ class TagMutator
     /**
      * @throws Exception|IllegalObjectTypeException
      */
-    public function createTag(Types\TagLabel $label, Types\AssetCollectionId $assetCollectionId = null): Types\Tag
-    {
+    public function createTag(
+        Types\TagLabel $label,
+        Types\AssetSourceId $assetSourceId,
+        Types\AssetCollectionId $assetCollectionId = null,
+    ): ?Types\Tag {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only support managing tags in the neos asset source
+            throw new Exception(
+                $this->localizedMessage('actions.assetSourceNotSupported', 'Asset source not supported'),
+                1776332600
+            );
+        }
+
         $tag = $this->tagRepository->findOneByLabel($label->value);
         if ($tag === null) {
             $tag = new Tag($label);
@@ -82,8 +99,16 @@ class TagMutator
     /**
      * @throws Exception|IllegalObjectTypeException
      */
-    public function updateTag(Types\TagId $id, Types\TagLabel $label = null): Types\Tag
-    {
+    public function updateTag(
+        Types\TagId $id,
+        Types\AssetSourceId $assetSourceId,
+        Types\TagLabel $label = null
+    ): ?Types\Tag {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only support managing tags in the neos asset source
+            return null;
+        }
+
         /** @var Tag $tag */
         $tag = $this->tagRepository->findByIdentifier($id->value);
         if (!$tag) {
@@ -105,8 +130,17 @@ class TagMutator
     /**
      * @throws Exception|IllegalObjectTypeException|InvalidQueryException
      */
-    public function deleteTag(Types\TagId $id): MutationResult
-    {
+    public function deleteTag(
+        Types\TagId $id,
+        Types\AssetSourceId $assetSourceId
+    ): MutationResult {
+        if ($assetSourceId->value !== 'neos') {
+            // We currently only support managing tags in the neos asset source
+            return MutationResult::fromError([
+                $this->localizedMessage('actions.assetSourceNotSupported', 'Asset source not supported')
+            ]);
+        }
+
         /** @var Tag $tag */
         $tag = $this->tagRepository->findByIdentifier($id->value);
         if (!$tag) {

--- a/Classes/GraphQL/Mutator/TagMutator.php
+++ b/Classes/GraphQL/Mutator/TagMutator.php
@@ -27,8 +27,6 @@ use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Repository\TagRepository;
 
-use function Wwwision\Types\instantiate;
-
 #[Flow\Scope("singleton")]
 class TagMutator
 {
@@ -90,10 +88,11 @@ class TagMutator
                 throw new Exception('Asset collection not found', 1603921193);
             }
         }
-        return instantiate(Types\Tag::class, [
-            'id' => $this->persistenceManager->getIdentifierByObject($tag),
-            'label' => $tag->getLabel(),
-        ]);
+        return Types\Tag::create(
+            Types\TagId::fromString($this->persistenceManager->getIdentifierByObject($tag)),
+            $assetSourceId,
+            Types\TagLabel::fromString($tag->getLabel()),
+        );
     }
 
     /**
@@ -121,10 +120,11 @@ class TagMutator
 
         $this->tagRepository->update($tag);
 
-        return instantiate(Types\Tag::class, [
-            'id' => $this->persistenceManager->getIdentifierByObject($tag),
-            'label' => $tag->getLabel(),
-        ]);
+        return Types\Tag::create(
+            Types\TagId::fromString($this->persistenceManager->getIdentifierByObject($tag)),
+            $assetSourceId,
+            Types\TagLabel::fromString($tag->getLabel()),
+        );
     }
 
     /**

--- a/Classes/GraphQL/Resolver/Type/AssetCollectionResolver.php
+++ b/Classes/GraphQL/Resolver/Type/AssetCollectionResolver.php
@@ -26,8 +26,6 @@ use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\SiteRepository;
 
-use function Wwwision\Types\instantiate;
-
 #[Flow\Scope('singleton')]
 class AssetCollectionResolver
 {
@@ -86,10 +84,11 @@ class AssetCollectionResolver
         $originalAssetCollection = $this->assetCollectionRepository->findByIdentifier($assetCollection->id->value);
 
         return $originalAssetCollection ? Types\Tags::fromArray(array_map(
-            fn(Tag $tag) => instantiate(Types\Tag::class, [
-                'id' => $this->persistenceManager->getIdentifierByObject($tag),
-                'label' => $tag->getLabel(),
-            ]),
+            fn(Tag $tag) => Types\Tag::create(
+                Types\TagId::fromString($this->persistenceManager->getIdentifierByObject($tag)),
+                $assetCollection->assetSourceId,
+                Types\TagLabel::fromString($tag->getLabel()),
+            ),
             $originalAssetCollection->getTags()->toArray()
         )) : Types\Tags::empty();
     }
@@ -102,10 +101,10 @@ class AssetCollectionResolver
             return null;
         }
         $parent = $originalAssetCollection->getParent();
-        return $parent ? instantiate(Types\AssetCollectionParent::class, [
-            'id' => $this->persistenceManager->getIdentifierByObject($parent),
-            'title' => $parent->getTitle(),
-        ]) : null;
+        return $parent ? Types\AssetCollectionParent::create(
+            Types\AssetCollectionId::fromString($this->persistenceManager->getIdentifierByObject($parent)),
+            Types\AssetCollectionTitle::fromString($parent->getTitle()),
+        ) : null;
     }
 
     public function assets(Types\AssetCollection $assetCollection): Types\Assets

--- a/Classes/GraphQL/Resolver/Type/AssetResolver.php
+++ b/Classes/GraphQL/Resolver/Type/AssetResolver.php
@@ -28,8 +28,6 @@ use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Service\AssetService;
 use Neos\Media\Domain\Service\FileTypeIconService;
 
-use function Wwwision\Types\instantiate;
-
 #[Flow\Scope('singleton')]
 class AssetResolver
 {
@@ -57,7 +55,9 @@ class AssetResolver
      */
     public function label(Types\Asset $asset): ?string
     {
-        $localAssetData = $asset->localId ? $this->assetSourceContext->getAssetByLocalIdentifier($asset->localId) : null;
+        $localAssetData = $asset->localId ? $this->assetSourceContext->getAssetByLocalIdentifier(
+            $asset->localId
+        ) : null;
         if ($localAssetData && $localAssetData->getTitle()) {
             return $localAssetData->getTitle();
         }
@@ -115,7 +115,7 @@ class AssetResolver
             $url = (string)$assetProxy->getPreviewUri();
         }
 
-        return instantiate(Types\File::class, [
+        return Types\File::fromArray([
             'extension' => $icon['alt'],
             'mediaType' => $assetProxy->getMediaType(),
             'typeIcon' => [
@@ -139,9 +139,9 @@ class AssetResolver
             $properties = $assetProxy->getIptcProperties();
             return Types\IptcProperties::fromArray(
                 array_map(static function ($key) use ($properties) {
-                    return instantiate(
-                        Types\IptcProperty::class,
-                        ['propertyName' => $key, 'value' => $properties[$key]]
+                    return Types\IptcProperty::create(
+                        Types\IptcPropertyName::fromString($key),
+                        $properties[$key]
                     );
                 }, array_keys($properties))
             );
@@ -172,11 +172,12 @@ class AssetResolver
         $localAssetData = $this->assetSourceContext->getAssetByLocalIdentifier($asset->localId);
         return $localAssetData instanceof Asset ?
             Types\Tags::fromArray(
-                array_map(function (Tag $tag) {
-                    return instantiate(Types\Tag::class, [
-                        'id' => $this->persistenceManager->getIdentifierByObject($tag),
-                        'label' => $tag->getLabel(),
-                    ]);
+                array_map(function (Tag $tag) use ($asset) {
+                    return Types\Tag::create(
+                        Types\TagId::fromString($this->persistenceManager->getIdentifierByObject($tag)),
+                        $asset->assetSource->id,
+                        Types\TagLabel::fromString($tag->getLabel()),
+                    );
                 }, $localAssetData->getTags()->toArray())
             ) : Types\Tags::empty();
     }
@@ -189,13 +190,18 @@ class AssetResolver
         $localAssetData = $this->assetSourceContext->getAssetByLocalIdentifier($asset->localId);
         return $localAssetData instanceof Asset ?
             Types\AssetCollections::fromArray(
-                array_map(function (HierarchicalAssetCollectionInterface $assetCollection) {
-                    return instantiate(Types\AssetCollection::class, [
-                        'id' => $this->persistenceManager->getIdentifierByObject($assetCollection),
-                        'title' => $assetCollection->getTitle(),
-                        'path' => $assetCollection->getPath() ?
-                            Types\AssetCollectionPath::fromString($assetCollection->getPath()) : '',
-                    ]);
+                array_map(function (HierarchicalAssetCollectionInterface $assetCollection) use ($asset) {
+                    return Types\AssetCollection::create(
+                        Types\AssetCollectionId::fromString(
+                            $this->persistenceManager->getIdentifierByObject($assetCollection)
+                        ),
+                        $asset->assetSource->id,
+                        Types\AssetCollectionTitle::fromString($assetCollection->getTitle()),
+                        $assetCollection->getPath() ?
+                            Types\AssetCollectionPath::fromString(
+                                $assetCollection->getPath()
+                            ) : Types\AssetCollectionPath::fromString(''),
+                    );
                 },
                     $localAssetData->getAssetCollections()->toArray())
             ) : Types\AssetCollections::empty();

--- a/Classes/GraphQL/Types/AssetCollection.php
+++ b/Classes/GraphQL/Types/AssetCollection.php
@@ -13,8 +13,18 @@ final class AssetCollection
 {
     private function __construct(
         public readonly AssetCollectionId $id,
+        public readonly AssetSourceId $assetSourceId,
         public readonly AssetCollectionTitle $title,
         public readonly ?AssetCollectionPath $path = null,
     ) {
+    }
+
+    public static function create(
+        AssetCollectionId $id,
+        AssetSourceId $assetSourceId,
+        AssetCollectionTitle $title,
+        ?AssetCollectionPath $path = null,
+    ): self {
+        return new self($id, $assetSourceId, $title, $path);
     }
 }

--- a/Classes/GraphQL/Types/AssetCollectionParent.php
+++ b/Classes/GraphQL/Types/AssetCollectionParent.php
@@ -16,4 +16,9 @@ final class AssetCollectionParent
         public readonly AssetCollectionTitle $title,
     ) {
     }
+
+    public static function create(AssetCollectionId $assetCollectionId, AssetCollectionTitle $assetCollectionTitle): self
+    {
+        return new self($assetCollectionId, $assetCollectionTitle);
+    }
 }

--- a/Classes/GraphQL/Types/AssetIdentities.php
+++ b/Classes/GraphQL/Types/AssetIdentities.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\GraphQL\Types;
+
+use Neos\Flow\Annotations as Flow;
+use Wwwision\Types\Attributes\Description;
+use Wwwision\Types\Attributes\ListBased;
+
+#[Description('A list of asset identities')]
+#[Flow\Proxy(false)]
+#[ListBased(itemClassName: AssetIdentity::class)]
+final class AssetIdentities implements \IteratorAggregate
+{
+    /**
+     * @param AssetIdentity[] $collections
+     */
+    private function __construct(public readonly array $collections)
+    {
+    }
+
+    /**
+     * @param AssetIdentity[] $assetIdentities
+     */
+    public static function fromArray(array $assetIdentities): self
+    {
+        return new self($assetIdentities);
+    }
+
+    /**
+     * @return \Traversable<AssetIdentity>
+     */
+    public function getIterator(): \Traversable
+    {
+        yield from $this->collections;
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+}

--- a/Classes/GraphQL/Types/AssetIdentity.php
+++ b/Classes/GraphQL/Types/AssetIdentity.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\Media\Ui\GraphQL\Types;
+
+use Neos\Flow\Annotations as Flow;
+use Wwwision\Types\Attributes\Description;
+
+#[Description('Unique identity of an Asset in an asset-source')]
+#[Flow\Proxy(false)]
+final readonly class AssetIdentity implements \JsonSerializable
+{
+    private function __construct(
+        public AssetId $assetId,
+        public AssetSourceId $assetSourceId,
+    ) {
+    }
+
+    public static function create(AssetId $assetId, AssetSourceId $assetSourceId): self
+    {
+        return new self($assetId, $assetSourceId);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->assetId,
+            'assetSourceId' => $this->assetSourceId,
+        ];
+    }
+}

--- a/Classes/GraphQL/Types/AssetSourceId.php
+++ b/Classes/GraphQL/Types/AssetSourceId.php
@@ -17,6 +17,11 @@ final class AssetSourceId implements \JsonSerializable
     {
     }
 
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
     public function jsonSerialize(): string
     {
         return $this->value;

--- a/Classes/GraphQL/Types/AssetSources.php
+++ b/Classes/GraphQL/Types/AssetSources.php
@@ -14,14 +14,14 @@ use Wwwision\Types\Attributes\ListBased;
 final class AssetSources implements \IteratorAggregate
 {
     /**
-     * @param AssetSource[] $collections
+     * @param array<string, AssetSource> $items
      */
-    private function __construct(public readonly array $collections)
+    private function __construct(public readonly array $items)
     {
     }
 
     /**
-     * @param AssetSource[] $assetSources
+     * @param array<string, AssetSource> $assetSources
      */
     public static function fromArray(array $assetSources): self
     {
@@ -33,7 +33,7 @@ final class AssetSources implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        yield from $this->collections;
+        yield from $this->items;
     }
 
     public static function empty(): self

--- a/Classes/GraphQL/Types/File.php
+++ b/Classes/GraphQL/Types/File.php
@@ -19,4 +19,15 @@ final class File
         public readonly Url $url,
     ) {
     }
+
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            FileExtension::fromString($array['extension']),
+            MediaType::fromString($array['mediaType']),
+            Image::fromArray($array['typeIcon']),
+            FileSize::fromInteger($array['size']),
+            Url::fromString($array['url']),
+        );
+    }
 }

--- a/Classes/GraphQL/Types/FileExtension.php
+++ b/Classes/GraphQL/Types/FileExtension.php
@@ -17,6 +17,11 @@ final class FileExtension implements \JsonSerializable
     {
     }
 
+    public static function fromString(string $extension): self
+    {
+        return new self($extension);
+    }
+
     public function jsonSerialize(): string
     {
         return $this->value;

--- a/Classes/GraphQL/Types/FileSize.php
+++ b/Classes/GraphQL/Types/FileSize.php
@@ -17,6 +17,11 @@ final class FileSize implements \JsonSerializable
     {
     }
 
+    public static function fromInteger(int $value): self
+    {
+        return new self($value);
+    }
+
     public function jsonSerialize(): int
     {
         return $this->value;

--- a/Classes/GraphQL/Types/FileUploadResult.php
+++ b/Classes/GraphQL/Types/FileUploadResult.php
@@ -18,6 +18,16 @@ final class FileUploadResult implements \JsonSerializable
     ) {
     }
 
+    public static function fromSuccess(string $result, ?Filename $filename = null): self
+    {
+        return new self(true, $result, $filename);
+    }
+
+    public static function fromError(string $result): self
+    {
+        return new self(false, $result);
+    }
+
     public function jsonSerialize(): array
     {
         return [

--- a/Classes/GraphQL/Types/FileUploadResults.php
+++ b/Classes/GraphQL/Types/FileUploadResults.php
@@ -12,14 +12,14 @@ use Wwwision\Types\Attributes\ListBased;
 final class FileUploadResults implements \IteratorAggregate, \JsonSerializable
 {
     /**
-     * @param FileUploadResult[] $values
+     * @param array<string, FileUploadResult> $values
      */
     private function __construct(public readonly array $values)
     {
     }
 
     /**
-     * @param FileUploadResult[] $results
+     * @param array<string, FileUploadResult> $results
      */
     public static function fromArray(array $results): self
     {

--- a/Classes/GraphQL/Types/Image.php
+++ b/Classes/GraphQL/Types/Image.php
@@ -18,4 +18,9 @@ final class Image
         public readonly string $alt,
     ) {
     }
+
+    public static function fromArray(array $fields): self
+    {
+        return new self($fields['width'], $fields['height'], $fields['url'], $fields['alt']);
+    }
 }

--- a/Classes/GraphQL/Types/IptcProperty.php
+++ b/Classes/GraphQL/Types/IptcProperty.php
@@ -16,4 +16,9 @@ final class IptcProperty
         public readonly string $value,
     ) {
     }
+
+    public static function create(IptcPropertyName $propertyName, string $value): self
+    {
+        return new self($propertyName, $value);
+    }
 }

--- a/Classes/GraphQL/Types/IptcPropertyName.php
+++ b/Classes/GraphQL/Types/IptcPropertyName.php
@@ -17,6 +17,11 @@ final class IptcPropertyName implements \JsonSerializable
     {
     }
 
+    public static function fromString(string $key): self
+    {
+        return new self($key);
+    }
+
     public function jsonSerialize(): string
     {
         return $this->value;

--- a/Classes/GraphQL/Types/MediaType.php
+++ b/Classes/GraphQL/Types/MediaType.php
@@ -17,6 +17,11 @@ final class MediaType implements \JsonSerializable
     {
     }
 
+    public static function fromString(string $mediaType): self
+    {
+        return new self($mediaType);
+    }
+
     public function jsonSerialize(): string
     {
         return $this->value;

--- a/Classes/GraphQL/Types/Tag.php
+++ b/Classes/GraphQL/Types/Tag.php
@@ -9,11 +9,17 @@ use Wwwision\Types\Attributes\Description;
 
 #[Flow\Proxy(false)]
 #[Description('A tag to which assets can be assigned')]
-final class Tag
+final readonly class Tag
 {
     private function __construct(
-        public readonly TagId $id,
-        public readonly TagLabel $label,
+        public TagId $id,
+        public AssetSourceId $assetSourceId,
+        public TagLabel $label,
     ) {
+    }
+
+    public static function create(TagId $id, AssetSourceId $assetSourceId, TagLabel $label): self
+    {
+        return new self($id, $assetSourceId, $label);
     }
 }

--- a/Classes/Service/UsageDetailsService.php
+++ b/Classes/Service/UsageDetailsService.php
@@ -415,7 +415,7 @@ final class UsageDetailsService
      * @throws NonUniqueResultException
      * @throws Exception
      */
-    public function getUnusedAssetCount(): int
+    public function getUnusedAssetCount(Types\AssetSourceId $assetSourceId): int
     {
         // TODO: This method has to be implemented in a more generic way at some point to increase support with other implementations
         $this->canQueryAssetUsage();
@@ -433,7 +433,7 @@ final class UsageDetailsService
                 )
             ORDER BY a.lastModified DESC
         ', $this->getAssetVariantFilterClause('a')))
-            ->setParameter('assetSourceIdentifier', 'neos')
+            ->setParameter('assetSourceIdentifier', $assetSourceId->value)
             ->getSingleScalarResult();
     }
 

--- a/Resources/Private/GraphQL/schema.root.graphql
+++ b/Resources/Private/GraphQL/schema.root.graphql
@@ -9,17 +9,17 @@ type Query {
   """ Provides a filterable list of asset proxies. These are the main entities for media management. """
   assets(assetSourceId: AssetSourceId assetCollectionId: AssetCollectionId mediaType: MediaType assetType: AssetType tagId: TagId sortBy: SortBy sortDirection: SortDirection searchTerm: String limit: Int = 20 offset: Int = 0): [Asset!]
   """ All asset collections """
-  assetCollections: [AssetCollection!]!
+  assetCollections(assetSourceId: AssetSourceId): [AssetCollection!]!
   """ All configured asset sources (by default only the "neos" source) """
   assetSources: [AssetSource!]!
   """ Provides number of unused assets in local asset source """
-  unusedAssetCount: Int!
+  unusedAssetCount(assetSourceId: AssetSourceId): Int!
   """ Provides a list of all tags """
-  tags: [Tag!]!
+  tags(assetSourceId: AssetSourceId): [Tag!]!
   """ Get tag by id """
-  tag(id: TagId!): Tag
+  tag(id: TagId! assetSourceId: AssetSourceId): Tag
   """ Returns an asset collection by id """
-  assetCollection(id: AssetCollectionId!): AssetCollection
+  assetCollection(id: AssetCollectionId! assetSourceId: AssetSourceId!): AssetCollection
   """ Returns an asset by id """
   asset(id: AssetId! assetSourceId: AssetSourceId!): Asset
   """ Provides configuration values for interacting with the media API """
@@ -29,7 +29,7 @@ type Query {
   """ Returns the total usage count for the given asset """
   assetUsageCount(id: AssetId! assetSourceId: AssetSourceId!): Int!
   """ Provides a list of all unused assets in local asset source """
-  unusedAssets(limit: Int = 20 offset: Int = 0): [Asset!]!
+  unusedAssets(assetSourceId: AssetSourceId! limit: Int = 20 offset: Int = 0): [Asset!]!
   """ Provides a list of changes to assets since a given timestamp """
   changedAssets(since: DateTime @constraint(format: "date_time")): ChangedAssetsResult!
   """ Returns a list of variants for the given asset """
@@ -44,18 +44,18 @@ type Mutation {
   deleteAsset(id: AssetId! assetSourceId: AssetSourceId!): MutationResult!
   setAssetTags(id: AssetId! assetSourceId: AssetSourceId! tagIds: [TagId!]!): Asset
   setAssetCollections(id: AssetId! assetSourceId: AssetSourceId! assetCollectionIds: [AssetCollectionId!]!): MutationResult!
-  createAssetCollection(title: AssetCollectionTitle! parent: AssetCollectionId): AssetCollection
-  deleteAssetCollection(id: AssetCollectionId!): MutationResult!
-  updateAssetCollection(id: AssetCollectionId! title: AssetCollectionTitle tagIds: [TagId!]): MutationResult!
-  setAssetCollectionParent(id: AssetCollectionId! parent: AssetCollectionId): MutationResult!
+  createAssetCollection(title: AssetCollectionTitle! assetSourceId: AssetSourceId! parent: AssetCollectionId): AssetCollection
+  deleteAssetCollection(id: AssetCollectionId! assetSourceId: AssetSourceId!): MutationResult!
+  updateAssetCollection(id: AssetCollectionId! assetSourceId: AssetSourceId! title: AssetCollectionTitle tagIds: [TagId!]): MutationResult!
+  setAssetCollectionParent(id: AssetCollectionId! assetSourceId: AssetSourceId! parent: AssetCollectionId): MutationResult!
   replaceAsset(id: AssetId! assetSourceId: AssetSourceId! file: UploadedFileInput! options: AssetReplacementOptionsInput!): FileUploadResult!
   editAsset(id: AssetId! assetSourceId: AssetSourceId! filename: Filename! options: AssetEditOptionsInput!): MutationResult!
   importAsset(id: AssetId! assetSourceId: AssetSourceId!): Asset
-  uploadFile(file: UploadedFileInput tagId: TagId assetCollectionId: AssetCollectionId): FileUploadResult!
-  uploadFiles(files: [UploadedFileInput!] tagId: TagId assetCollectionId: AssetCollectionId): [FileUploadResult!]!
-  createTag(label: TagLabel! assetCollectionId: AssetCollectionId): Tag!
-  updateTag(id: TagId! label: TagLabel): Tag!
-  deleteTag(id: TagId!): MutationResult!
+  uploadFile(file: UploadedFileInput tagId: TagId assetCollectionId: AssetCollectionId assetSourceId: AssetSourceId): FileUploadResult!
+  uploadFiles(files: [UploadedFileInput!] tagId: TagId assetCollectionId: AssetCollectionId assetSourceId: AssetSourceId): [FileUploadResult!]!
+  createTag(label: TagLabel! assetSourceId: AssetSourceId! assetCollectionId: AssetCollectionId): Tag!
+  updateTag(id: TagId! assetSourceId: AssetSourceId! label: TagLabel): Tag!
+  deleteTag(id: TagId! assetSourceId: AssetSourceId!): MutationResult!
 }
 
 """
@@ -178,6 +178,8 @@ scalar TagLabel
 type Tag {
   """ The id of a tag """
   id: TagId!
+  """ Unique identifier of an Asset source (e.g. "neos") """
+  assetSourceId: AssetSourceId!
   """ The label of a Tag (e.g. "important") """
   label: TagLabel!
 }
@@ -202,6 +204,8 @@ type AssetCollectionParent {
 type AssetCollection {
   """ Unique identifier of an Asset collection (e.g. "neos") """
   id: AssetCollectionId!
+  """ Unique identifier of an Asset source (e.g. "neos") """
+  assetSourceId: AssetSourceId!
   """ The title of an Asset collection (e.g. "slideshows") """
   title: AssetCollectionTitle!
   """ Absolute path of an Asset collection (e.g. "/photos/trees") """

--- a/Resources/Private/GraphQL/schema.root.graphql
+++ b/Resources/Private/GraphQL/schema.root.graphql
@@ -51,8 +51,8 @@ type Mutation {
   replaceAsset(id: AssetId! assetSourceId: AssetSourceId! file: UploadedFileInput! options: AssetReplacementOptionsInput!): FileUploadResult!
   editAsset(id: AssetId! assetSourceId: AssetSourceId! filename: Filename! options: AssetEditOptionsInput!): MutationResult!
   importAsset(id: AssetId! assetSourceId: AssetSourceId!): Asset
-  uploadFile(file: UploadedFileInput tagId: TagId assetCollectionId: AssetCollectionId assetSourceId: AssetSourceId): FileUploadResult!
-  uploadFiles(files: [UploadedFileInput!] tagId: TagId assetCollectionId: AssetCollectionId assetSourceId: AssetSourceId): [FileUploadResult!]!
+  uploadFile(file: UploadedFileInput! assetSourceId: AssetSourceId! tagId: TagId assetCollectionId: AssetCollectionId): FileUploadResult!
+  uploadFiles(files: [UploadedFileInput!] assetSourceId: AssetSourceId tagId: TagId assetCollectionId: AssetCollectionId): [FileUploadResult!]!
   createTag(label: TagLabel! assetSourceId: AssetSourceId! assetCollectionId: AssetCollectionId): Tag!
   updateTag(id: TagId! assetSourceId: AssetSourceId! label: TagLabel): Tag!
   deleteTag(id: TagId! assetSourceId: AssetSourceId!): MutationResult!

--- a/Tests/Functional/AbstractMediaTestCase.php
+++ b/Tests/Functional/AbstractMediaTestCase.php
@@ -47,42 +47,36 @@ abstract class AbstractMediaTestCase extends FunctionalTestCase
 
     /**
      * Creates an Image object from a file using a mock resource (in order to avoid a database resource pointer entry)
-     * @param string $imagePathAndFilename
-     * @return PersistentResource
      */
-    protected function getMockResourceByImagePath($imagePathAndFilename)
+    protected function getMockResourceByImagePath(string $imagePathAndFilename): PersistentResource
     {
         $imagePathAndFilename = Files::getUnixStylePath($imagePathAndFilename);
         $hash = sha1_file($imagePathAndFilename);
         copy($imagePathAndFilename, 'resource://' . $hash);
-        return $mockResource = $this->createMockResourceAndPointerFromHash($hash);
+        return $this->createMockResourceAndPointerFromHash($hash);
     }
 
     /**
      * Creates a mock ResourcePointer and PersistentResource from a given hash.
      * Make sure that a file representation already exists, e.g. with
      * file_put_content('resource://' . $hash) before
-     *
-     * @param string $hash
-     * @return PersistentResource
      */
-    protected function createMockResourceAndPointerFromHash($hash)
+    protected function createMockResourceAndPointerFromHash(string $hash): PersistentResource
     {
         $mockResource = $this->getMockBuilder(PersistentResource::class)->setMethods(['getHash', 'getUri'])->getMock();
-        $mockResource->expects(self::any())
+        $mockResource
                 ->method('getHash')
-                ->will(self::returnValue($hash));
-        $mockResource->expects(self::any())
+                ->willReturn($hash);
+        $mockResource
             ->method('getUri')
-            ->will(self::returnValue('resource://' . $hash));
+            ->willReturn('resource://' . $hash);
         return $mockResource;
     }
 
     /**
      * Builds a temporary directory to work on.
-     * @return void
      */
-    protected function prepareTemporaryDirectory()
+    protected function prepareTemporaryDirectory(): void
     {
         $this->temporaryDirectory = Files::concatenatePaths([FLOW_PATH_DATA, 'Temporary', 'Testing', str_replace('\\', '_', __CLASS__)]);
         if (!file_exists($this->temporaryDirectory)) {

--- a/Tests/Functional/Domain/Model/AssetCollectionTest.php
+++ b/Tests/Functional/Domain/Model/AssetCollectionTest.php
@@ -53,11 +53,11 @@ class AssetCollectionTest extends AbstractMediaTestCase
      */
     public function parentChildrenRelation(): void
     {
-        /** @var HierarchicalAssetCollectionInterface $child1 */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $child1 */
         $child1 = new AssetCollection('child1');
-        /** @var HierarchicalAssetCollectionInterface $child2 */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $child2 */
         $child2 = new AssetCollection('child2');
-        /** @var HierarchicalAssetCollectionInterface $parent */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $parent */
         $parent = new AssetCollection('parent');
 
         $child1->setParent($parent);
@@ -90,11 +90,11 @@ class AssetCollectionTest extends AbstractMediaTestCase
      */
     public function circularParentChildrenRelationThrowsErrorWhenSettingParent(): void
     {
-        /** @var HierarchicalAssetCollectionInterface $firstCollection */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $firstCollection */
         $firstCollection = new AssetCollection('first');
-        /** @var HierarchicalAssetCollectionInterface $secondCollection */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $secondCollection */
         $secondCollection = new AssetCollection('second');
-        /** @var HierarchicalAssetCollectionInterface $thirdCollection */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $thirdCollection */
         $thirdCollection = new AssetCollection('third');
 
         $secondCollection->setParent($firstCollection);
@@ -109,9 +109,9 @@ class AssetCollectionTest extends AbstractMediaTestCase
      */
     public function unsettingTheParentRemovesChildFromParent(): void
     {
-        /** @var HierarchicalAssetCollectionInterface $child */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $child */
         $child = new AssetCollection('child');
-        /** @var HierarchicalAssetCollectionInterface $parent */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $parent */
         $parent = new AssetCollection('parent');
 
         $child->setParent($parent);
@@ -122,7 +122,7 @@ class AssetCollectionTest extends AbstractMediaTestCase
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
-        /** @var HierarchicalAssetCollectionInterface $persistedChild */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $persistedChild */
         $persistedChild = $this->assetCollectionRepository->findOneByTitle('child');
         $persistedChild->setParent(null);
 
@@ -144,9 +144,9 @@ class AssetCollectionTest extends AbstractMediaTestCase
      */
     public function deletingTheParentDeletesTheChild(): void
     {
-        /** @var HierarchicalAssetCollectionInterface $child */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $child */
         $child = new AssetCollection('child');
-        /** @var HierarchicalAssetCollectionInterface $parent */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $parent */
         $parent = new AssetCollection('parent');
 
         $child->setParent($parent);
@@ -175,9 +175,9 @@ class AssetCollectionTest extends AbstractMediaTestCase
      */
     public function hasParentReturnsTrueIfParentIsSet(): void
     {
-        /** @var HierarchicalAssetCollectionInterface $child */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $child */
         $child = new AssetCollection('child');
-        /** @var HierarchicalAssetCollectionInterface $parent */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $parent */
         $parent = new AssetCollection('parent');
 
         $child->setParent($parent);
@@ -234,9 +234,9 @@ class AssetCollectionTest extends AbstractMediaTestCase
      */
     public function pathOfSubCollectionContainsPathOfParentCollection(): void
     {
-        /** @var HierarchicalAssetCollectionInterface $parent */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $parent */
         $parent = new AssetCollection('Parent');
-        /** @var HierarchicalAssetCollectionInterface $child */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $child */
         $child = new AssetCollection('Child');
         $child->setParent($parent);
 
@@ -257,9 +257,9 @@ class AssetCollectionTest extends AbstractMediaTestCase
      */
     public function pathOfSubCollectionUpdatesWhenParentIsRenamed(): void
     {
-        /** @var HierarchicalAssetCollectionInterface $parent */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $parent */
         $parent = new AssetCollection('Parent');
-        /** @var HierarchicalAssetCollectionInterface $child */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $child */
         $child = new AssetCollection('Child');
         $child->setParent($parent);
 

--- a/Tests/Functional/Domain/Repository/AssetCollectionRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/AssetCollectionRepositoryTest.php
@@ -47,11 +47,11 @@ class AssetCollectionRepositoryTest extends AbstractMediaTestCase
      */
     public function parentRemoveRemovesCompleteHierarchy(): void
     {
-        /** @var HierarchicalAssetCollectionInterface $grandchild */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $grandchild */
         $grandchild = new AssetCollection('grandChild');
-        /** @var HierarchicalAssetCollectionInterface $child */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $child */
         $child = new AssetCollection('child');
-        /** @var HierarchicalAssetCollectionInterface $parent */
+        /** @var HierarchicalAssetCollectionInterface&AssetCollection $parent */
         $parent = new AssetCollection('parent');
         $child->setParent($parent);
         $grandchild->setParent($child);

--- a/Tests/Functional/GraphQL/AssetApiTest.php
+++ b/Tests/Functional/GraphQL/AssetApiTest.php
@@ -41,6 +41,7 @@ class AssetApiTest extends AbstractMediaTestCase
     protected AssetResolver $assetResolver;
     protected TestAssetUsageStrategy $testAssetUsageStrategy;
     protected AssetRepository $assetRepository;
+    protected false $isolated;
 
     public function setUp(): void
     {
@@ -64,7 +65,7 @@ class AssetApiTest extends AbstractMediaTestCase
     public function testUploadFile(): void
     {
         $file = self::createFile();
-        $result = $this->mediaApi->uploadFile($file);
+        $result = $this->mediaApi->uploadFile($file, Types\AssetSourceId::default());
 
         $this->assertTrue($result->success);
         $this->assertEquals('test.svg', $result->filename->value);
@@ -74,11 +75,12 @@ class AssetApiTest extends AbstractMediaTestCase
     {
         $file = self::createFile();
         $result = $this->mediaApi->uploadFiles(
-            Types\UploadedFiles::fromArray([$file])
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
         );
 
         $this->assertCount(1, $result->values);
-        $uploadResult = $result->getIterator()->current();
+        $uploadResult = $result->values['test.svg'] ?? null;
         $this->assertInstanceOf(Types\FileUploadResult::class, $uploadResult);
         $this->assertTrue($uploadResult->success);
         $this->assertEquals('test.svg', $uploadResult->filename->value);
@@ -88,13 +90,14 @@ class AssetApiTest extends AbstractMediaTestCase
     {
         $file = self::createFile();
         $result = $this->mediaApi->uploadFiles(
-            Types\UploadedFiles::fromArray([$file])
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
         );
         $this->assertCount(1, $result->values);
 
         $this->persistenceManager->persistAll();
 
-        $asset = $this->mediaApi->assets()->assets[0];
+        $asset = $this->mediaApi->assets(Types\AssetSourceId::default())->assets[0];
         $this->assertEquals($file->clientFilename, $asset->filename->value);
 
         // Edit the asset
@@ -108,18 +111,21 @@ class AssetApiTest extends AbstractMediaTestCase
         );
 
         $this->assertTrue($editResult->success);
-        $editedAsset = $this->mediaApi->assets()->assets[0];
+        $editedAsset = $this->mediaApi->assets(Types\AssetSourceId::default())->assets[0];
         $this->assertEquals('new-name.svg', $editedAsset->filename->value);
     }
 
     public function testDeleteUnusedAssetWorks(): void
     {
         $file = self::createFile();
-        $result = $this->mediaApi->uploadFiles(Types\UploadedFiles::fromArray([$file]));
+        $result = $this->mediaApi->uploadFiles(
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
+        );
         $this->assertCount(1, $result->values);
         $this->persistenceManager->persistAll();
 
-        $asset = $this->mediaApi->assets()->assets[0];
+        $asset = $this->mediaApi->assets(Types\AssetSourceId::default())->assets[0];
         $this->assertEquals($file->clientFilename, $asset->filename->value);
 
         // Delete the asset
@@ -127,17 +133,20 @@ class AssetApiTest extends AbstractMediaTestCase
         $this->persistenceManager->persistAll();
 
         $this->assertTrue($deleteResult->success);
-        $assetsAfterDeletion = $this->mediaApi->assets();
+        $assetsAfterDeletion = $this->mediaApi->assets(Types\AssetSourceId::default());
         $this->assertCount(0, $assetsAfterDeletion);
     }
 
     public function testDeleteUsedAssetFails(): void
     {
         $file = self::createFile();
-        $result = $this->mediaApi->uploadFiles(Types\UploadedFiles::fromArray([$file]));
+        $result = $this->mediaApi->uploadFiles(
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
+        );
         $this->assertCount(1, $result->values);
         $this->persistenceManager->persistAll();
-        $asset = $this->mediaApi->assets()->assets[0];
+        $asset = $this->mediaApi->assets(Types\AssetSourceId::default())->assets[0];
 
         // Get the actual asset entity from repository and mark it as used
         $assetEntity = $this->assetRepository->findByIdentifier($asset->id->value);
@@ -148,7 +157,7 @@ class AssetApiTest extends AbstractMediaTestCase
         $this->persistenceManager->persistAll();
 
         $this->assertFalse($deleteResult->success);
-        $assetsAfterDeletion = $this->mediaApi->assets();
+        $assetsAfterDeletion = $this->mediaApi->assets(Types\AssetSourceId::default());
         $this->assertCount(1, $assetsAfterDeletion);
     }
 
@@ -156,13 +165,14 @@ class AssetApiTest extends AbstractMediaTestCase
     {
         $file = self::createFile();
         $result = $this->mediaApi->uploadFiles(
-            Types\UploadedFiles::fromArray([$file])
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
         );
         $this->assertCount(1, $result->values);
         $this->persistenceManager->persistAll();
 
-        $assets = $this->mediaApi->assets();
-        $asset = $assets->getIterator()->current();
+        $assets = $this->mediaApi->assets(Types\AssetSourceId::default());
+        $asset = $assets->assets[0];
         $this->assertEquals($file->clientFilename, $asset->filename->value);
 
         $updatedAsset = $this->mediaApi->updateAsset(
@@ -183,13 +193,14 @@ class AssetApiTest extends AbstractMediaTestCase
     {
         $file = self::createFile();
         $result = $this->mediaApi->uploadFiles(
-            Types\UploadedFiles::fromArray([$file])
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
         );
         $this->assertCount(1, $result->values);
         $this->persistenceManager->persistAll();
 
-        $assets = $this->mediaApi->assets();
-        $asset = $assets->getIterator()->current();
+        $assets = $this->mediaApi->assets(Types\AssetSourceId::default());
+        $asset = $assets->assets[0];
         $this->assertEquals($file->clientFilename, $asset->filename->value);
 
         $fetchedAsset = $this->mediaApi->asset(
@@ -201,29 +212,30 @@ class AssetApiTest extends AbstractMediaTestCase
 
     public function testAssetCount(): void
     {
-        $assetCount = $this->mediaApi->assetCount();
+        $assetCount = $this->mediaApi->assetCount(Types\AssetSourceId::default());
         $this->assertEquals(0, $assetCount);
 
         $file = self::createFile();
         $result = $this->mediaApi->uploadFiles(
-            Types\UploadedFiles::fromArray([$file])
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
         );
         $this->assertCount(1, $result->values);
         $this->persistenceManager->persistAll();
 
-        $assetCount = $this->mediaApi->assetCount();
+        $assetCount = $this->mediaApi->assetCount(Types\AssetSourceId::default());
         $this->assertEquals(1, $assetCount);
 
-        $unusedAssetCount = $this->mediaApi->unusedAssetCount();
+        $unusedAssetCount = $this->mediaApi->unusedAssetCount(Types\AssetSourceId::default());
         $this->assertEquals(1, $unusedAssetCount);
     }
 
     public function testAssetSources(): void
     {
         $assetSources = $this->mediaApi->assetSources();
-        $this->assertGreaterThanOrEqual(1, count($assetSources->collections));
-        $assetSource = $assetSources->getIterator()->current();
-        $this->assertEquals('Neos', $assetSource->label);
+        $this->assertGreaterThanOrEqual(1, count($assetSources->items));
+        $assetSource = $assetSources->items['neos'] ?? null;
+        $this->assertEquals('Neos', $assetSource?->label);
     }
 
     public function testConfig(): void
@@ -243,13 +255,14 @@ class AssetApiTest extends AbstractMediaTestCase
     {
         $file = self::createFile();
         $result = $this->mediaApi->uploadFiles(
-            Types\UploadedFiles::fromArray([$file])
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
         );
         $this->assertCount(1, $result->values);
         $this->persistenceManager->persistAll();
 
-        $assets = $this->mediaApi->assets();
-        $asset = $assets->getIterator()->current();
+        $assets = $this->mediaApi->assets(Types\AssetSourceId::default());
+        $asset = $assets->assets[0];
         $usageDetails = $this->mediaApi->assetUsageDetails(
             $asset->id,
             $asset->assetSource->id,
@@ -263,13 +276,14 @@ class AssetApiTest extends AbstractMediaTestCase
     {
         $file = self::createFile();
         $result = $this->mediaApi->uploadFiles(
-            Types\UploadedFiles::fromArray([$file])
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
         );
         $this->assertCount(1, $result->values);
         $this->persistenceManager->persistAll();
 
-        $assets = $this->mediaApi->assets();
-        $asset = $assets->getIterator()->current();
+        $assets = $this->mediaApi->assets(Types\AssetSourceId::default());
+        $asset = $assets->assets[0];
         $usageCount = $this->mediaApi->assetUsageCount(
             $asset->id,
             $asset->assetSource->id,
@@ -286,13 +300,14 @@ class AssetApiTest extends AbstractMediaTestCase
     {
         $file = self::createFile();
         $result = $this->mediaApi->uploadFiles(
-            Types\UploadedFiles::fromArray([$file])
+            Types\UploadedFiles::fromArray([$file]),
+            Types\AssetSourceId::default(),
         );
         $this->assertCount(1, $result->values);
         $this->persistenceManager->persistAll();
 
         $unusedAssets = $this->mediaApi->unusedAssets(Types\AssetSourceId::default());
-        $unusedAsset = $unusedAssets->getIterator()->current();
+        $unusedAsset = $unusedAssets->assets[0];
         $this->assertCount(1, $unusedAssets);
         $this->assertEquals($file->clientFilename, $unusedAsset->filename->value);
     }

--- a/Tests/Functional/GraphQL/AssetApiTest.php
+++ b/Tests/Functional/GraphQL/AssetApiTest.php
@@ -291,7 +291,7 @@ class AssetApiTest extends AbstractMediaTestCase
         $this->assertCount(1, $result->values);
         $this->persistenceManager->persistAll();
 
-        $unusedAssets = $this->mediaApi->unusedAssets();
+        $unusedAssets = $this->mediaApi->unusedAssets(Types\AssetSourceId::default());
         $unusedAsset = $unusedAssets->getIterator()->current();
         $this->assertCount(1, $unusedAssets);
         $this->assertEquals($file->clientFilename, $unusedAsset->filename->value);

--- a/Tests/Functional/GraphQL/AssetCollectionApiTest.php
+++ b/Tests/Functional/GraphQL/AssetCollectionApiTest.php
@@ -43,12 +43,14 @@ class AssetCollectionApiTest extends AbstractMediaTestCase
     {
         $assetCollection = $this->mediaApi->createAssetCollection(
             Types\AssetCollectionTitle::fromString('Test Collection'),
+            Types\AssetSourceId::default(),
         );
         $this->assertInstanceOf(Types\AssetCollection::class, $assetCollection);
         $this->assertEquals('Test Collection', $assetCollection->title->value);
 
         $childCollection = $this->mediaApi->createAssetCollection(
             Types\AssetCollectionTitle::fromString('Child Collection'),
+            Types\AssetSourceId::default(),
             $assetCollection->id,
         );
 
@@ -60,18 +62,22 @@ class AssetCollectionApiTest extends AbstractMediaTestCase
     {
         $assetCollection = $this->mediaApi->createAssetCollection(
             Types\AssetCollectionTitle::fromString('Test Collection'),
+            Types\AssetSourceId::default(),
         );
-        $result = $this->mediaApi->deleteAssetCollection($assetCollection->id);
+        $result = $this->mediaApi->deleteAssetCollection($assetCollection->id, Types\AssetSourceId::default());
 
         $this->assertTrue($result->success);
 
-        $assetCollection = $this->mediaApi->assetCollection($assetCollection->id);
+        $assetCollection = $this->mediaApi->assetCollection($assetCollection->id, Types\AssetSourceId::default());
         $this->assertNull($assetCollection);
     }
 
     public function testDeleteNonExistingAssetCollection(): void
     {
-        $result = $this->mediaApi->deleteAssetCollection(Types\AssetCollectionId::fromString('non-existing-id'));
+        $result = $this->mediaApi->deleteAssetCollection(
+            Types\AssetCollectionId::fromString('non-existing-id'),
+            Types\AssetSourceId::default(),
+        );
 
         $this->assertFalse($result->success);
     }
@@ -80,15 +86,20 @@ class AssetCollectionApiTest extends AbstractMediaTestCase
     {
         $assetCollection = $this->mediaApi->createAssetCollection(
             Types\AssetCollectionTitle::fromString('Test Collection'),
+            Types\AssetSourceId::default(),
         );
         $result = $this->mediaApi->updateAssetCollection(
             $assetCollection->id,
+            Types\AssetSourceId::default(),
             Types\AssetCollectionTitle::fromString('Updated Collection'),
         );
 
         $this->assertTrue($result->success);
 
-        $updatedAssetCollection = $this->mediaApi->assetCollection($assetCollection->id);
+        $updatedAssetCollection = $this->mediaApi->assetCollection(
+            $assetCollection->id,
+            Types\AssetSourceId::default()
+        );
 
         $this->assertEquals('Updated Collection', $updatedAssetCollection->title->value);
     }
@@ -97,25 +108,29 @@ class AssetCollectionApiTest extends AbstractMediaTestCase
     {
         $parentCollection = $this->mediaApi->createAssetCollection(
             Types\AssetCollectionTitle::fromString('Parent Collection'),
+            Types\AssetSourceId::default(),
         );
         $childCollection = $this->mediaApi->createAssetCollection(
             Types\AssetCollectionTitle::fromString('Child Collection'),
+            Types\AssetSourceId::default(),
         );
 
         $result = $this->mediaApi->setAssetCollectionParent(
             $childCollection->id,
+            Types\AssetSourceId::default(),
             $parentCollection->id,
         );
         $this->assertTrue($result->success);
 
-        $updatedChildCollection = $this->mediaApi->assetCollection($childCollection->id);
+        $updatedChildCollection = $this->mediaApi->assetCollection($childCollection->id, Types\AssetSourceId::default(),);
         $this->assertTrue(str_starts_with($updatedChildCollection->path->value, $parentCollection->path->value));
 
         $this->mediaApi->setAssetCollectionParent(
             $childCollection->id,
+            Types\AssetSourceId::default(),
         );
 
-        $updatedChildCollection = $this->mediaApi->assetCollection($childCollection->id);
+        $updatedChildCollection = $this->mediaApi->assetCollection($childCollection->id, Types\AssetSourceId::default(),);
         $this->assertEquals($childCollection->path->value, $updatedChildCollection->path->value);
     }
 }

--- a/Tests/Functional/GraphQL/AssetCollectionApiTest.php
+++ b/Tests/Functional/GraphQL/AssetCollectionApiTest.php
@@ -29,6 +29,8 @@ class AssetCollectionApiTest extends AbstractMediaTestCase
      */
     protected static $testablePersistenceEnabled = true;
 
+    protected MediaApi $mediaApi;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/Tests/Functional/GraphQL/TagApiTest.php
+++ b/Tests/Functional/GraphQL/TagApiTest.php
@@ -31,6 +31,10 @@ class TagApiTest extends AbstractMediaTestCase
      */
     protected static $testablePersistenceEnabled = true;
 
+    protected MediaApi $mediaApi;
+    protected AssetCollectionResolver $assetCollectionResolver;
+    protected AssetResolver $assetResolver;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -68,7 +72,7 @@ class TagApiTest extends AbstractMediaTestCase
 
         $this->assertTrue($result->success);
 
-        $deletedTag = $this->mediaApi->tag($tag->id);
+        $deletedTag = $this->mediaApi->tag($tag->id, Types\AssetSourceId::default());
         $this->assertNull($deletedTag);
     }
 
@@ -83,7 +87,7 @@ class TagApiTest extends AbstractMediaTestCase
             Types\AssetSourceId::default(),
             $assetCollection->id
         );
-        $createdTag = $this->mediaApi->tag($tag->id);
+        $createdTag = $this->mediaApi->tag($tag->id, Types\AssetSourceId::default());
 
         $resolvedTags = $this->assetCollectionResolver->tags($assetCollection);
         $this->assertCount(1, $resolvedTags->tags);
@@ -97,15 +101,17 @@ class TagApiTest extends AbstractMediaTestCase
     public function testTagAsset(): void
     {
         $file = self::createFile();
-        $result = $this->mediaApi->uploadFile($file);
+        $result = $this->mediaApi->uploadFile($file, Types\AssetSourceId::default());
         $this->assertTrue($result->success);
 
         $this->persistenceManager->persistAll();
-        $assets = $this->mediaApi->assets();
-        /** @var Types\Asset $uploadedAsset */
-        $uploadedAsset = $assets->getIterator()->current();
+        $assets = $this->mediaApi->assets(Types\AssetSourceId::default());
+        $uploadedAsset = $assets->assets[0];
 
-        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'), Types\AssetSourceId::default());
+        $tag = $this->mediaApi->createTag(
+            Types\TagLabel::fromString('Test Tag'),
+            Types\AssetSourceId::default()
+        );
         $this->mediaApi->tagAsset(
             $uploadedAsset->id,
             $uploadedAsset->assetSource->id,

--- a/Tests/Functional/GraphQL/TagApiTest.php
+++ b/Tests/Functional/GraphQL/TagApiTest.php
@@ -45,22 +45,26 @@ class TagApiTest extends AbstractMediaTestCase
 
     public function testCreateTag(): void
     {
-        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'));
+        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'), Types\AssetSourceId::default());
         $this->assertEquals('Test Tag', $tag->label);
     }
 
     public function testUpdateTag(): void
     {
-        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'));
-        $updatedTag = $this->mediaApi->updateTag($tag->id, Types\TagLabel::fromString('Updated Tag'));
+        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'), Types\AssetSourceId::default());
+        $updatedTag = $this->mediaApi->updateTag(
+            $tag->id,
+            Types\AssetSourceId::default(),
+            Types\TagLabel::fromString('Updated Tag')
+        );
 
         $this->assertEquals('Updated Tag', $updatedTag->label);
     }
 
     public function testDeleteTag(): void
     {
-        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'));
-        $result = $this->mediaApi->deleteTag($tag->id);
+        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'), Types\AssetSourceId::default());
+        $result = $this->mediaApi->deleteTag($tag->id, Types\AssetSourceId::default());
 
         $this->assertTrue($result->success);
 
@@ -71,9 +75,14 @@ class TagApiTest extends AbstractMediaTestCase
     public function testTagAssetCollection(): void
     {
         $assetCollection = $this->mediaApi->createAssetCollection(
-            Types\AssetCollectionTitle::fromString('Test Collection')
+            Types\AssetCollectionTitle::fromString('Test Collection'),
+            Types\AssetSourceId::default(),
         );
-        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'), $assetCollection->id);
+        $tag = $this->mediaApi->createTag(
+            Types\TagLabel::fromString('Test Tag'),
+            Types\AssetSourceId::default(),
+            $assetCollection->id
+        );
         $createdTag = $this->mediaApi->tag($tag->id);
 
         $resolvedTags = $this->assetCollectionResolver->tags($assetCollection);
@@ -96,7 +105,7 @@ class TagApiTest extends AbstractMediaTestCase
         /** @var Types\Asset $uploadedAsset */
         $uploadedAsset = $assets->getIterator()->current();
 
-        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'));
+        $tag = $this->mediaApi->createTag(Types\TagLabel::fromString('Test Tag'), Types\AssetSourceId::default());
         $this->mediaApi->tagAsset(
             $uploadedAsset->id,
             $uploadedAsset->assetSource->id,

--- a/Tests/Functional/TestAssetUsageStrategy.php
+++ b/Tests/Functional/TestAssetUsageStrategy.php
@@ -15,6 +15,7 @@ namespace Flowpack\Media\Ui\Tests\Functional;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\Dto\UsageReference;
 use Neos\Media\Domain\Strategy\AbstractAssetUsageStrategy;
@@ -51,30 +52,28 @@ class TestAssetUsageStrategy extends AbstractAssetUsageStrategy
 
     /**
      * Mark an asset as being used
-     *
-     * @param AssetInterface $asset
-     * @return void
      */
     public function markAssetAsUsed(AssetInterface $asset): void
     {
+        if (!$asset instanceof Asset) {
+            throw new \InvalidArgumentException('Only Asset entities can be marked as used in TestAssetUsageStrategy');
+        }
         $this->usedAssets[$asset->getIdentifier()] = $asset;
     }
 
     /**
      * Mark an asset as not being used
-     *
-     * @param AssetInterface $asset
-     * @return void
      */
     public function markAssetAsUnused(AssetInterface $asset): void
     {
+        if (!$asset instanceof Asset) {
+            throw new \InvalidArgumentException('Only Asset entities can be marked as used in TestAssetUsageStrategy');
+        }
         unset($this->usedAssets[$asset->getIdentifier()]);
     }
 
     /**
      * Reset all usage markings
-     *
-     * @return void
      */
     public function reset(): void
     {
@@ -84,15 +83,16 @@ class TestAssetUsageStrategy extends AbstractAssetUsageStrategy
     /**
      * Returns an array of usage reference objects.
      *
-     * @param AssetInterface $asset
-     * @return array<\Neos\Media\Domain\Model\Dto\UsageReference>
+     * @return array<UsageReference>
      */
     public function getUsageReferences(AssetInterface $asset): array
     {
+        if (!$asset instanceof Asset) {
+            throw new \InvalidArgumentException('Only Asset entities can be marked as used in TestAssetUsageStrategy');
+        }
         if (isset($this->usedAssets[$asset->getIdentifier()])) {
             return [new UsageReference($asset)];
         }
-
         return [];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "test": "../../../bin/phpunit --enforce-time-limit --bootstrap ../../Libraries/autoload.php --testdox Tests",
     "test:ci": "phpunit --enforce-time-limit --bootstrap vendor/autoload.php --testdox Tests",
     "codestyle": "phpstan analyse --autoload-file ../../Libraries/autoload.php",
-    "codestyle:ci": "phpstan analyse"
+    "codestyle:ci": "phpstan analyse --autoload-file vendor/autoload.php"
   },
   "license": "GPL-3.0-or-later",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
   "scripts": {
     "test": "../../../bin/phpunit --enforce-time-limit --bootstrap ../../Libraries/autoload.php --testdox Tests",
     "test:ci": "phpunit --enforce-time-limit --bootstrap vendor/autoload.php --testdox Tests",
-    "codestyle": "phpstan analyse --autoload-file ../../Libraries/autoload.php",
-    "codestyle:ci": "phpstan analyse --autoload-file vendor/autoload.php"
+    "codestyle": "phpstan analyse --autoload-file ../../Libraries/autoload.php -c phpstan.neon"
   },
   "license": "GPL-3.0-or-later",
   "autoload": {

--- a/packages/asset-collections/src/components/AssetCollectionTree.tsx
+++ b/packages/asset-collections/src/components/AssetCollectionTree.tsx
@@ -36,9 +36,9 @@ const DraggedNodeRenderer: React.FC<{
 
 const AssetCollectionTree = () => {
     const { translate } = useIntl();
-    const { assetCollections } = useAssetCollectionsQuery();
     const selectedAssetSource = useSelectedAssetSource();
-    const { tags } = useTagsQuery();
+    const { assetCollections } = useAssetCollectionsQuery(selectedAssetSource?.id);
+    const { tags } = useTagsQuery(selectedAssetSource?.id);
     const { assetCount: totalAssetCount } = useAssetCountQuery(true);
     const [assetCollectionTreeView, setAssetCollectionTreeViewState] = useRecoilState(assetCollectionTreeViewState);
     const favourites = useRecoilValue(assetCollectionFavouritesState);

--- a/packages/asset-collections/src/components/AssetCollectionTreeNode.tsx
+++ b/packages/asset-collections/src/components/AssetCollectionTreeNode.tsx
@@ -7,6 +7,7 @@ import dndTypes from '@media-ui/core/src/constants/dndTypes';
 import { selectedAssetCollectionAndTagState } from '@media-ui/core/src/state';
 import { IconStack } from '@media-ui/core/src/components';
 import { useConfigQuery } from '@media-ui/core/src/hooks';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 import TagTreeNode from './TagTreeNode';
 import { useAssetCollectionQuery, UNASSIGNED_COLLECTION_ID } from '../hooks/useAssetCollectionQuery';
@@ -32,7 +33,8 @@ const AssetCollectionTreeNode: React.FC<AssetCollectionTreeNodeProps> = ({
     renderChildCollections = true,
 }) => {
     const { config } = useConfigQuery();
-    const { assetCollection } = useAssetCollectionQuery(assetCollectionId);
+    const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
+    const { assetCollection } = useAssetCollectionQuery(assetCollectionId, selectedAssetSourceId);
     const { assetCollections } = useAssetCollectionsQuery();
     const [collapsed, setCollapsed] = useRecoilState(assetCollectionTreeCollapsedItemState(assetCollectionId));
     const selectAssetCollectionAndTag = useSetRecoilState(selectedAssetCollectionAndTagState);

--- a/packages/asset-collections/src/components/DeleteButton.tsx
+++ b/packages/asset-collections/src/components/DeleteButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { IconButton } from '@neos-project/react-ui-components';
 
@@ -7,6 +7,7 @@ import { useIntl, useMediaUi, useNotify } from '@media-ui/core';
 import { useConfigQuery } from '@media-ui/core/src/hooks';
 import { selectedAssetCollectionAndTagState } from '@media-ui/core/src/state';
 import { useDeleteTag, useSelectedTag } from '@media-ui/feature-asset-tags';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 import useDeleteAssetCollection from '../hooks/useDeleteAssetCollection';
 import useSelectedAssetCollection from '../hooks/useSelectedAssetCollection';
@@ -16,6 +17,7 @@ const DeleteButton: React.FC = () => {
     const { config } = useConfigQuery();
     const Notify = useNotify();
     const { approvalAttainmentStrategy } = useMediaUi();
+    const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
     const selectedAssetCollection = useSelectedAssetCollection();
     const selectedTag = useSelectedTag();
     const { deleteTag } = useDeleteTag();
@@ -28,7 +30,7 @@ const DeleteButton: React.FC = () => {
                 tag: selectedTag,
             });
             if (!canDeleteTag) return;
-            deleteTag(selectedTag.id)
+            deleteTag(selectedTag.id, selectedAssetSourceId)
                 .then(() => {
                     Notify.ok(translate('action.deleteTag.success', 'The tag has been deleted'));
                     setSelectedAssetCollectionAndTag(({ assetCollectionId }) => ({ tagId: null, assetCollectionId }));
@@ -42,7 +44,7 @@ const DeleteButton: React.FC = () => {
             });
             if (!canDeleteAssetCollection) return;
 
-            deleteAssetCollection(selectedAssetCollection.id)
+            deleteAssetCollection(selectedAssetCollection.id, selectedAssetSourceId)
                 .then(() => {
                     Notify.ok(
                         translate('assetCollectionActions.delete.success', 'Asset collection was successfully deleted')
@@ -56,11 +58,12 @@ const DeleteButton: React.FC = () => {
     }, [
         selectedTag,
         selectedAssetCollection,
-        translate,
-        deleteTag,
-        Notify,
-        setSelectedAssetCollectionAndTag,
         approvalAttainmentStrategy,
+        deleteTag,
+        selectedAssetSourceId,
+        Notify,
+        translate,
+        setSelectedAssetCollectionAndTag,
         deleteAssetCollection,
     ]);
 

--- a/packages/asset-collections/src/fragments/assetCollection.ts
+++ b/packages/asset-collections/src/fragments/assetCollection.ts
@@ -4,6 +4,7 @@ import { TAG_FRAGMENT } from '@media-ui/feature-asset-tags/src/fragments/tag';
 export const ASSET_COLLECTION_FRAGMENT = gql`
     fragment AssetCollectionProps on AssetCollection {
         id
+        assetSourceId
         title
         parent {
             id

--- a/packages/asset-collections/src/hooks/useAssetCollectionQuery.ts
+++ b/packages/asset-collections/src/hooks/useAssetCollectionQuery.ts
@@ -8,10 +8,13 @@ interface AssetCollectionQueryResult {
 
 export const UNASSIGNED_COLLECTION_ID = 'UNASSIGNED';
 
-export function useAssetCollectionQuery(assetCollectionId?: string) {
-    const { data, loading, refetch } = useQuery<AssetCollectionQueryResult, { id: string }>(ASSET_COLLECTION, {
-        variables: { id: assetCollectionId },
-        skip: !assetCollectionId || assetCollectionId === UNASSIGNED_COLLECTION_ID,
+export function useAssetCollectionQuery(assetCollectionId: string | null, assetSourceId: AssetSourceId | null) {
+    const { data, loading, refetch } = useQuery<
+        AssetCollectionQueryResult,
+        { id: AssetCollectionId; assetSourceId: AssetSourceId }
+    >(ASSET_COLLECTION, {
+        variables: { id: assetCollectionId, assetSourceId },
+        skip: !assetCollectionId || !assetSourceId || assetCollectionId === UNASSIGNED_COLLECTION_ID,
     });
     return { assetCollection: data?.assetCollection || null, loading, refetch };
 }

--- a/packages/asset-collections/src/hooks/useAssetCollectionsQuery.ts
+++ b/packages/asset-collections/src/hooks/useAssetCollectionsQuery.ts
@@ -6,7 +6,10 @@ interface AssetCollectionsQueryResult {
     assetCollections: AssetCollection[];
 }
 
-export default function useAssetCollectionsQuery() {
-    const { data, loading } = useQuery<AssetCollectionsQueryResult>(ASSET_COLLECTIONS);
+export default function useAssetCollectionsQuery(assetSourceId?: AssetSourceId) {
+    const { data, loading } = useQuery<AssetCollectionsQueryResult>(ASSET_COLLECTIONS, {
+        variables: { assetSourceId },
+        skip: !assetSourceId,
+    });
     return { assetCollections: data?.assetCollections || [], loading };
 }

--- a/packages/asset-collections/src/hooks/useCreateAssetCollection.ts
+++ b/packages/asset-collections/src/hooks/useCreateAssetCollection.ts
@@ -4,8 +4,9 @@ import { CREATE_ASSET_COLLECTION } from '../mutations/createAssetCollection';
 import { ASSET_COLLECTIONS } from '../queries/assetCollections';
 
 interface CreateAssetCollectionVariables {
-    title: string;
-    parent: string | null;
+    title: AssetCollectionTitle;
+    assetSourceId: AssetSourceId;
+    parent: AssetCollectionPath | null;
 }
 
 export default function useCreateAssetCollection() {
@@ -14,10 +15,15 @@ export default function useCreateAssetCollection() {
         CreateAssetCollectionVariables
     >(CREATE_ASSET_COLLECTION);
 
-    const createAssetCollection = (title: string, parentCollectionId: string = null) =>
+    const createAssetCollection = (
+        title: AssetCollectionTitle,
+        assetSourceId: AssetSourceId,
+        parentCollectionId: AssetCollectionPath = null
+    ) =>
         action({
             variables: {
                 title,
+                assetSourceId,
                 parent: parentCollectionId,
             },
             update(cache, { data }) {

--- a/packages/asset-collections/src/hooks/useDeleteAssetCollection.ts
+++ b/packages/asset-collections/src/hooks/useDeleteAssetCollection.ts
@@ -4,7 +4,8 @@ import { ASSET_COLLECTIONS } from '../queries/assetCollections';
 import { DELETE_ASSET_COLLECTION } from '../mutations/deleteAssetCollection';
 
 interface DeleteAssetCollectionVariables {
-    id: string;
+    id: AssetCollectionId;
+    assetSourceId: AssetSourceId;
 }
 
 export default function useDeleteAssetCollection() {
@@ -13,10 +14,11 @@ export default function useDeleteAssetCollection() {
         DeleteAssetCollectionVariables
     >(DELETE_ASSET_COLLECTION);
 
-    const deleteAssetCollection = (id: string) =>
+    const deleteAssetCollection = (id: AssetCollectionId, assetSourceId: AssetSourceId) =>
         action({
             variables: {
                 id,
+                assetSourceId,
             },
             optimisticResponse: {
                 deleteAssetCollection: {

--- a/packages/asset-collections/src/hooks/useSelectedAssetCollection.ts
+++ b/packages/asset-collections/src/hooks/useSelectedAssetCollection.ts
@@ -6,13 +6,15 @@ import { ASSET_COLLECTION } from '../queries/assetCollection';
 
 interface AssetCollectionQueryResult {
     assetCollection: AssetCollection;
+    assetSourceId?: AssetSourceId;
 }
 
 const useSelectedAssetCollection = (): AssetCollection => {
+    const assetSourceId = useRecoilValue(selectedAssetCollectionIdState);
     const selectedAssetCollectionId = useRecoilValue(selectedAssetCollectionIdState);
 
     const { data } = useQuery<AssetCollectionQueryResult>(ASSET_COLLECTION, {
-        variables: { id: selectedAssetCollectionId },
+        variables: { id: selectedAssetCollectionId, assetSourceId },
         skip: !selectedAssetCollectionId,
     });
 

--- a/packages/asset-collections/src/hooks/useSetAssetCollectionParent.ts
+++ b/packages/asset-collections/src/hooks/useSetAssetCollectionParent.ts
@@ -5,12 +5,14 @@ import { SET_ASSET_COLLECTION_PARENT } from '../mutations/setAssetCollectionPare
 
 interface SetAssetCollectionParentProps {
     assetCollection: AssetCollection;
+    assetSourceId: AssetSourceId;
     parent: AssetCollection | null;
 }
 
 interface SetAssetCollectionParentVariables {
-    id: string;
-    parent?: string;
+    id: AssetCollectionId;
+    assetSourceId: AssetSourceId;
+    parent?: AssetCollectionId;
 }
 
 export function useSetAssetCollectionParent() {
@@ -20,10 +22,11 @@ export function useSetAssetCollectionParent() {
     >(SET_ASSET_COLLECTION_PARENT);
 
     const setAssetCollectionParent = useCallback(
-        ({ assetCollection, parent }: SetAssetCollectionParentProps) =>
+        ({ assetCollection, assetSourceId, parent }: SetAssetCollectionParentProps) =>
             action({
                 variables: {
                     id: assetCollection.id,
+                    assetSourceId,
                     parent: parent?.id,
                 },
                 optimisticResponse: {

--- a/packages/asset-collections/src/hooks/useUpdateAssetCollection.ts
+++ b/packages/asset-collections/src/hooks/useUpdateAssetCollection.ts
@@ -5,16 +5,18 @@ import { UPDATE_ASSET_COLLECTION } from '../mutations/updateAssetCollection';
 
 interface UpdateAssetCollectionProps {
     assetCollection: AssetCollection;
-    title?: string;
+    assetSourceId: AssetSourceId;
+    title?: AssetCollectionTitle;
     tags?: Tag[];
     parent?: AssetCollection;
 }
 
 interface UpdateAssetCollectionVariables {
-    id: string;
-    title?: string;
-    tagIds?: string[];
-    parent?: string;
+    id: AssetCollectionId;
+    assetSourceId: AssetSourceId;
+    title?: AssetCollectionTitle;
+    tagIds?: TagId[];
+    parent?: AssetCollectionId;
 }
 
 export default function useUpdateAssetCollection() {
@@ -24,10 +26,11 @@ export default function useUpdateAssetCollection() {
     >(UPDATE_ASSET_COLLECTION);
 
     const updateAssetCollection = useCallback(
-        ({ assetCollection, title, tags, parent }: UpdateAssetCollectionProps) =>
+        ({ assetCollection, assetSourceId, title, tags, parent }: UpdateAssetCollectionProps) =>
             action({
                 variables: {
                     id: assetCollection.id,
+                    assetSourceId,
                     title,
                     tagIds: tags?.map((tag) => tag.id),
                     parent: parent === null ? null : parent?.id,

--- a/packages/asset-collections/src/mutations/createAssetCollection.ts
+++ b/packages/asset-collections/src/mutations/createAssetCollection.ts
@@ -3,8 +3,12 @@ import { gql } from '@apollo/client';
 import { ASSET_COLLECTION_FRAGMENT } from '../fragments/assetCollection';
 
 export const CREATE_ASSET_COLLECTION = gql`
-    mutation CreateAssetCollection($title: AssetCollectionTitle!, $parent: AssetCollectionId) {
-        createAssetCollection(title: $title, parent: $parent) {
+    mutation CreateAssetCollection(
+        $title: AssetCollectionTitle!
+        $assetSourceId: AssetSourceId!
+        $parent: AssetCollectionId
+    ) {
+        createAssetCollection(title: $title, assetSourceId: $assetSourceId, parent: $parent) {
             ...AssetCollectionProps
         }
     }

--- a/packages/asset-collections/src/mutations/deleteAssetCollection.ts
+++ b/packages/asset-collections/src/mutations/deleteAssetCollection.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const DELETE_ASSET_COLLECTION = gql`
-    mutation DeleteAssetCollection($id: AssetCollectionId!) {
-        deleteAssetCollection(id: $id) {
+    mutation DeleteAssetCollection($id: AssetCollectionId!, $assetSourceId: AssetSourceId!) {
+        deleteAssetCollection(id: $id, assetSourceId: $assetSourceId) {
             success
             messages
         }

--- a/packages/asset-collections/src/mutations/setAssetCollectionParent.ts
+++ b/packages/asset-collections/src/mutations/setAssetCollectionParent.ts
@@ -1,8 +1,12 @@
 import { gql } from '@apollo/client';
 
 export const SET_ASSET_COLLECTION_PARENT = gql`
-    mutation SetAssetCollectionParent($id: AssetCollectionId!, $parent: AssetCollectionId) {
-        setAssetCollectionParent(id: $id, parent: $parent) {
+    mutation SetAssetCollectionParent(
+        $id: AssetCollectionId!
+        $assetSourceId: AssetSourceId!
+        $parent: AssetCollectionId
+    ) {
+        setAssetCollectionParent(id: $id, assetSourceId: $assetSourceId, parent: $parent) {
             success
             messages
         }

--- a/packages/asset-collections/src/mutations/updateAssetCollection.ts
+++ b/packages/asset-collections/src/mutations/updateAssetCollection.ts
@@ -1,8 +1,13 @@
 import { gql } from '@apollo/client';
 
 export const UPDATE_ASSET_COLLECTION = gql`
-    mutation UpdateAssetCollection($id: AssetCollectionId!, $title: AssetCollectionTitle, $tagIds: [TagId!]) {
-        updateAssetCollection(id: $id, title: $title, tagIds: $tagIds) {
+    mutation UpdateAssetCollection(
+        $id: AssetCollectionId!
+        $assetSourceId: AssetSourceId!
+        $title: AssetCollectionTitle
+        $tagIds: [TagId!]
+    ) {
+        updateAssetCollection(id: $id, assetSourceId: $assetSourceId, title: $title, tagIds: $tagIds) {
             success
             messages
         }

--- a/packages/asset-collections/src/provider/AssetCollectionTreeDndProvider.tsx
+++ b/packages/asset-collections/src/provider/AssetCollectionTreeDndProvider.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback, useState, createContext, useContext } from 'react';
 import { DndProvider } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
+import { useRecoilValue } from 'recoil';
 
 import { useIntl, useNotify } from '@media-ui/core';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 import { useSetAssetCollectionParent } from '../hooks/useSetAssetCollectionParent';
 import useAssetCollectionsQuery from '../hooks/useAssetCollectionsQuery';
@@ -27,7 +29,8 @@ export const useAssetCollectionDnd = (): AssetCollectionTreeDndProviderValues =>
 export function AssetCollectionTreeDndProvider({ children }: AssetCollectionTreeDndProviderProps) {
     const { translate } = useIntl();
     const Notify = useNotify();
-    const { assetCollections } = useAssetCollectionsQuery();
+    const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
+    const { assetCollections } = useAssetCollectionsQuery(selectedAssetSourceId);
     const [currentlyDraggedNodes, setCurrentlyDraggedNodes] = useState<string[]>([]);
     const { setAssetCollectionParent } = useSetAssetCollectionParent();
 
@@ -58,6 +61,7 @@ export function AssetCollectionTreeDndProvider({ children }: AssetCollectionTree
                 if (targetParentCollection?.id !== draggedAssetCollection.parent?.id) {
                     setAssetCollectionParent({
                         assetCollection: draggedAssetCollection,
+                        assetSourceId: selectedAssetSourceId,
                         parent: targetParentCollection,
                     })
                         .then(() => {
@@ -82,7 +86,7 @@ export function AssetCollectionTreeDndProvider({ children }: AssetCollectionTree
 
             setCurrentlyDraggedNodes([]);
         },
-        [Notify, assetCollections, currentlyDraggedNodes, setAssetCollectionParent, setCurrentlyDraggedNodes, translate]
+        [Notify, assetCollections, currentlyDraggedNodes, selectedAssetSourceId, setAssetCollectionParent, translate]
     );
 
     const acceptsDraggedNode = useCallback(

--- a/packages/asset-collections/src/queries/assetCollection.ts
+++ b/packages/asset-collections/src/queries/assetCollection.ts
@@ -3,8 +3,8 @@ import { gql } from '@apollo/client';
 import { ASSET_COLLECTION_FRAGMENT } from '../fragments/assetCollection';
 
 export const ASSET_COLLECTION = gql`
-    query ASSET_COLLECTION($id: AssetCollectionId!) {
-        assetCollection(id: $id) {
+    query ASSET_COLLECTION($id: AssetCollectionId!, $assetSourceId: AssetSourceId!) {
+        assetCollection(id: $id, assetSourceId: $assetSourceId) {
             ...AssetCollectionProps
         }
     }

--- a/packages/asset-collections/src/queries/assetCollections.ts
+++ b/packages/asset-collections/src/queries/assetCollections.ts
@@ -3,8 +3,8 @@ import { gql } from '@apollo/client';
 import { ASSET_COLLECTION_FRAGMENT } from '../fragments/assetCollection';
 
 export const ASSET_COLLECTIONS = gql`
-    query ASSET_COLLECTIONS {
-        assetCollections {
+    query ASSET_COLLECTIONS($assetSourceId: AssetSourceId!) {
+        assetCollections(assetSourceId: $assetSourceId) {
             ...AssetCollectionProps
         }
     }

--- a/packages/asset-collections/typings/AssetCollection.d.ts
+++ b/packages/asset-collections/typings/AssetCollection.d.ts
@@ -1,14 +1,17 @@
 type AssetCollectionType = 'AssetCollection';
 
 type AssetCollectionId = string;
+type AssetCollectionTitle = string;
+type AssetCollectionPath = string;
 
 interface AssetCollection extends GraphQlEntity {
     __typename: AssetCollectionType;
     readonly id: AssetCollectionId;
-    readonly title: string;
+    readonly assetSourceId: AssetSourceId;
+    readonly title: AssetCollectionTitle;
     parent?: AssetCollectionParent;
     tags?: Tag[];
     assetCount: number;
-    path?: string;
+    path?: AssetCollectionPath;
     canDelete: boolean;
 }

--- a/packages/asset-sources/src/components/AssetSourceList.tsx
+++ b/packages/asset-sources/src/components/AssetSourceList.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import { useRecoilState } from 'recoil';
+import React, { useCallback } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import cx from 'classnames';
 
 import { Headline } from '@neos-project/react-ui-components';
 
 import { useIntl } from '@media-ui/core';
 import { IconLabel } from '@media-ui/core/src/components';
+import { selectedAssetIdState } from '@media-ui/core/src/state';
+import { selectedAssetCollectionIdState } from '@media-ui/feature-asset-collections';
 
 import { selectedAssetSourceState } from '../state/selectedAssetSourceState';
 import { useAssetSourcesQuery } from '../hooks/useAssetSourcesQuery';
@@ -16,6 +18,17 @@ const AssetSourceList: React.FC = () => {
     const { assetSources } = useAssetSourcesQuery();
     const { translate } = useIntl();
     const [selectedAssetSourceId, setSelectedAssetSourceId] = useRecoilState(selectedAssetSourceState);
+    const setSelectedAsset = useSetRecoilState(selectedAssetIdState);
+    const setSelectedAssetCollection = useSetRecoilState(selectedAssetCollectionIdState);
+
+    const chooseSelectedAssetSource = useCallback(
+        (assetSourceId: AssetSourceId) => {
+            setSelectedAsset(null);
+            setSelectedAssetCollection(null);
+            setSelectedAssetSourceId(assetSourceId);
+        },
+        [setSelectedAsset, setSelectedAssetCollection, setSelectedAssetSourceId]
+    );
 
     // We don't show the source selection if there is only one
     if (!assetSources || assetSources.length < 2) return null;
@@ -30,7 +43,7 @@ const AssetSourceList: React.FC = () => {
                     key={assetSource.id}
                     type="button"
                     className={cx(classes.item, selectedAssetSourceId === assetSource.id && classes.itemSelected)}
-                    onClick={() => setSelectedAssetSourceId(assetSource.id)}
+                    onClick={() => chooseSelectedAssetSource(assetSource.id)}
                 >
                     <IconLabel
                         label={assetSource.id === 'neos' ? translate('assetSource.local', 'Local') : assetSource.label}

--- a/packages/asset-sources/src/state/selectedAssetSourceState.ts
+++ b/packages/asset-sources/src/state/selectedAssetSourceState.ts
@@ -5,13 +5,13 @@ import { clipboardVisibleState } from '@media-ui/feature-clipboard';
 
 export const NEOS_ASSET_SOURCE = 'neos';
 
-const selectedAssetSourceIdState = atom<string>({
+const selectedAssetSourceIdState = atom<AssetSourceId>({
     key: 'SelectedAssetSourceIdState',
     default: NEOS_ASSET_SOURCE,
     effects: [localStorageEffect('SelectedAssetSourceIdState')],
 });
 
-export const selectedAssetSourceState = selector<string>({
+export const selectedAssetSourceState = selector<AssetSourceId>({
     key: 'SelectedAssetSourceState',
     get: ({ get }) => {
         const selectedAssetSourceId = get(selectedAssetSourceIdState);

--- a/packages/asset-tags/src/components/CreateTagDialog.tsx
+++ b/packages/asset-tags/src/components/CreateTagDialog.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useCallback } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { Button, Label, TextInput, Tooltip } from '@neos-project/react-ui-components';
 
@@ -12,14 +12,16 @@ import { Dialog } from '@media-ui/core/src/components';
 import createTagDialogState from '../state/createTagDialogState';
 
 import classes from './CreateTagDialog.module.css';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 const CreateTagDialog: React.FC = () => {
     const { translate } = useIntl();
     const Notify = useNotify();
+    const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
     const selectedAssetCollection = useSelectedAssetCollection();
     const [dialogState, setDialogState] = useRecoilState(createTagDialogState);
     const { createTag } = useCreateTag();
-    const { tags } = useTagsQuery();
+    const { tags } = useTagsQuery(selectedAssetSourceId);
 
     const handleRequestClose = useCallback(
         () =>

--- a/packages/asset-tags/src/fragments/tag.ts
+++ b/packages/asset-tags/src/fragments/tag.ts
@@ -3,6 +3,7 @@ import { gql } from '@apollo/client';
 export const TAG_FRAGMENT = gql`
     fragment TagProps on Tag {
         id
+        assetSourceId
         label
     }
 `;

--- a/packages/asset-tags/src/hooks/useCreateTag.ts
+++ b/packages/asset-tags/src/hooks/useCreateTag.ts
@@ -6,8 +6,9 @@ import TAGS from '../queries/tags';
 import CREATE_TAG from '../mutations/createTag';
 
 interface CreateTagVariables {
-    label: string;
-    assetCollectionId?: string;
+    label: TagLabel;
+    assetSourceId: AssetSourceId;
+    assetCollectionId?: AssetCollectionId;
 }
 
 export default function useCreateTag() {
@@ -15,9 +16,9 @@ export default function useCreateTag() {
         CREATE_TAG
     );
 
-    const createTag = (label: string, assetCollectionId?: string) =>
+    const createTag = (label: TagLabel, assetSourceId: AssetSourceId, assetCollectionId?: AssetCollectionId) =>
         action({
-            variables: { label, assetCollectionId },
+            variables: { label, assetSourceId, assetCollectionId },
             // FIXME: Optimistic response has to be adjusted as we don't know the id of the created tag
             // optimisticResponse: {
             //     __typename: 'Mutation',

--- a/packages/asset-tags/src/hooks/useDeleteTag.ts
+++ b/packages/asset-tags/src/hooks/useDeleteTag.ts
@@ -8,16 +8,17 @@ import TAGS from '../queries/tags';
 import DELETE_TAG from '../mutations/deleteTag';
 
 interface DeleteTagVariables {
-    id: string;
+    id: TagId;
+    assetSourceId: AssetSourceId;
 }
 
 export default function useDeleteTag() {
     const [action, { error, data }] = useMutation<{ deleteTag: MutationResult }, DeleteTagVariables>(DELETE_TAG);
     const [selectedTagId, setSelectedTagId] = useRecoilState(selectedTagIdState);
 
-    const deleteTag = (id: string) =>
+    const deleteTag = (id: TagId, assetSourceId: AssetSourceId) =>
         action({
-            variables: { id },
+            variables: { id, assetSourceId },
             optimisticResponse: {
                 deleteTag: {
                     success: true,

--- a/packages/asset-tags/src/hooks/useSelectedTag.ts
+++ b/packages/asset-tags/src/hooks/useSelectedTag.ts
@@ -3,13 +3,15 @@ import { useQuery } from '@apollo/client';
 
 import selectedTagIdState from '../state/selectedTagIdState';
 import TAG from '../queries/tag';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 interface TagQueryResult {
     tag: Tag;
     assetSourceId: AssetSourceId;
 }
 
-const useSelectedTag = (assetSourceId: AssetSourceId): Tag => {
+const useSelectedTag = (): Tag => {
+    const assetSourceId = useRecoilValue(selectedAssetSourceState);
     const selectedTagId = useRecoilValue(selectedTagIdState);
 
     const { data } = useQuery<TagQueryResult>(TAG, {

--- a/packages/asset-tags/src/hooks/useSelectedTag.ts
+++ b/packages/asset-tags/src/hooks/useSelectedTag.ts
@@ -6,13 +6,14 @@ import TAG from '../queries/tag';
 
 interface TagQueryResult {
     tag: Tag;
+    assetSourceId: AssetSourceId;
 }
 
-const useSelectedTag = (): Tag => {
+const useSelectedTag = (assetSourceId: AssetSourceId): Tag => {
     const selectedTagId = useRecoilValue(selectedTagIdState);
 
     const { data } = useQuery<TagQueryResult>(TAG, {
-        variables: { id: selectedTagId },
+        variables: { id: selectedTagId, assetSourceId },
         skip: !selectedTagId,
     });
 

--- a/packages/asset-tags/src/hooks/useTagsQuery.ts
+++ b/packages/asset-tags/src/hooks/useTagsQuery.ts
@@ -6,7 +6,7 @@ interface TagsQueryResult {
     tags: Tag[];
 }
 
-export default function useAssetTagsQuery(assetSourceId: AssetSourceId|null) {
+export default function useAssetTagsQuery(assetSourceId: AssetSourceId | null) {
     const { data, loading } = useQuery<TagsQueryResult>(TAGS, {
         variables: {
             assetSourceId,

--- a/packages/asset-tags/src/hooks/useTagsQuery.ts
+++ b/packages/asset-tags/src/hooks/useTagsQuery.ts
@@ -6,7 +6,12 @@ interface TagsQueryResult {
     tags: Tag[];
 }
 
-export default function useAssetTagsQuery() {
-    const { data, loading } = useQuery<TagsQueryResult>(TAGS);
+export default function useAssetTagsQuery(assetSourceId: AssetSourceId|null) {
+    const { data, loading } = useQuery<TagsQueryResult>(TAGS, {
+        variables: {
+            assetSourceId,
+        },
+        skip: !assetSourceId,
+    });
     return { tags: data?.tags || [], loading };
 }

--- a/packages/asset-tags/src/hooks/useUpdateTag.ts
+++ b/packages/asset-tags/src/hooks/useUpdateTag.ts
@@ -4,21 +4,24 @@ import UPDATE_TAG from '../mutations/updateTag';
 
 interface UpdateTagProps {
     tag: Tag;
-    label?: string;
+    assetSourceId: AssetSourceId;
+    label?: TagLabel;
 }
 
 interface UpdateTagVariables {
-    id: string;
-    label?: string;
+    id: TagId;
+    assetSourceId: AssetSourceId;
+    label?: TagLabel;
 }
 
 export default function useUpdateTag() {
     const [action, { error, data, loading }] = useMutation<{ updateTag: Tag }, UpdateTagVariables>(UPDATE_TAG);
 
-    const updateTag = ({ tag, label }: UpdateTagProps) =>
+    const updateTag = ({ tag, assetSourceId, label }: UpdateTagProps) =>
         action({
             variables: {
                 id: tag.id,
+                assetSourceId,
                 label,
             },
             optimisticResponse: {

--- a/packages/asset-tags/src/mutations/createTag.ts
+++ b/packages/asset-tags/src/mutations/createTag.ts
@@ -3,8 +3,8 @@ import { gql } from '@apollo/client';
 import { TAG_FRAGMENT } from '../fragments/tag';
 
 const CREATE_TAG = gql`
-    mutation CreateTag($label: TagLabel!, $assetCollectionId: AssetCollectionId) {
-        createTag(label: $label, assetCollectionId: $assetCollectionId) {
+    mutation CreateTag($label: TagLabel!, $assetSourceId: AssetSourceId!, $assetCollectionId: AssetCollectionId) {
+        createTag(label: $label, assetSourceId: $assetSourceId, assetCollectionId: $assetCollectionId) {
             ...TagProps
         }
     }

--- a/packages/asset-tags/src/mutations/deleteTag.ts
+++ b/packages/asset-tags/src/mutations/deleteTag.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 const DELETE_TAG = gql`
-    mutation DeleteTag($id: TagId!) {
-        deleteTag(id: $id) {
+    mutation DeleteTag($id: TagId!, $assetSourceId: AssetSourceId!) {
+        deleteTag(id: $id, assetSourceId: $assetSourceId) {
             success
             messages
         }

--- a/packages/asset-tags/src/mutations/updateTag.ts
+++ b/packages/asset-tags/src/mutations/updateTag.ts
@@ -3,8 +3,8 @@ import { gql } from '@apollo/client';
 import { TAG_FRAGMENT } from '../fragments/tag';
 
 const UPDATE_TAG = gql`
-    mutation UpdateTag($id: TagId!, $label: TagLabel!) {
-        updateTag(id: $id, label: $label) {
+    mutation UpdateTag($id: TagId!, $assetSourceId: AssetSourceId!, $label: TagLabel!) {
+        updateTag(id: $id, assetSourceId: $assetSourceId, label: $label) {
             ...TagProps
         }
     }

--- a/packages/asset-tags/src/queries/tag.ts
+++ b/packages/asset-tags/src/queries/tag.ts
@@ -3,8 +3,8 @@ import { gql } from '@apollo/client';
 import { TAG_FRAGMENT } from '../fragments/tag';
 
 const TAG = gql`
-    query TAG($id: TagId!) {
-        tag(id: $id) {
+    query TAG($id: TagId!, $assetSourceId: AssetSourceId!) {
+        tag(id: $id, assetSourceId: $assetSourceId) {
             ...TagProps
         }
     }

--- a/packages/asset-tags/src/queries/tags.ts
+++ b/packages/asset-tags/src/queries/tags.ts
@@ -3,8 +3,8 @@ import { gql } from '@apollo/client';
 import { TAG_FRAGMENT } from '../fragments/tag';
 
 const TAGS = gql`
-    query TAGS {
-        tags {
+    query TAGS($assetSourceId: AssetSourceId!) {
+        tags(assetSourceId: $assetSourceId) {
             ...TagProps
         }
     }

--- a/packages/asset-tags/typings/Tag.d.ts
+++ b/packages/asset-tags/typings/Tag.d.ts
@@ -1,7 +1,11 @@
 type TagType = 'Tag';
 
+type TagId = string;
+type TagLabel = string;
+
 interface Tag extends GraphQlEntity {
     __typename: TagType;
-    id: string;
-    label: string;
+    id: TagId;
+    assetSourceId: AssetSourceId;
+    label: TagLabel;
 }

--- a/packages/asset-usage/src/hooks/useUnusedAssetsQuery.ts
+++ b/packages/asset-usage/src/hooks/useUnusedAssetsQuery.ts
@@ -3,6 +3,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { useLazyQuery } from '@apollo/client';
 
 import { currentPageState, featureFlagsState, loadingState } from '@media-ui/core/src/state';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 import UNUSED_ASSETS from '../queries/unusedAssets';
 import showUnusedAssetsState from '../state/showUnusedAssetsState';
@@ -12,6 +13,7 @@ interface UnusedAssetsQueryResult {
 }
 
 interface UnusedAssetsQueryVariables {
+    assetSourceId: AssetSourceId;
     limit: number;
     offset: number;
 }
@@ -21,6 +23,7 @@ const useUnusedAssetsQuery = () => {
         pagination: { assetsPerPage },
     } = useRecoilValue(featureFlagsState);
     const currentPage = useRecoilValue(currentPageState);
+    const assetSourceId = useRecoilValue(selectedAssetSourceState);
     const [isLoading, setIsLoading] = useRecoilState(loadingState);
     const showUnusedAssets = useRecoilValue(showUnusedAssetsState);
     const [assets, setAssets] = useState<Asset[]>([]);
@@ -33,6 +36,7 @@ const useUnusedAssetsQuery = () => {
     >(UNUSED_ASSETS, {
         notifyOnNetworkStatusChange: false,
         variables: {
+            assetSourceId,
             limit: assetsPerPage,
             offset,
         },
@@ -42,6 +46,7 @@ const useUnusedAssetsQuery = () => {
         if (showUnusedAssets && !loading && !isLoading) {
             query({
                 variables: {
+                    assetSourceId,
                     limit: assetsPerPage,
                     offset,
                 },
@@ -51,7 +56,7 @@ const useUnusedAssetsQuery = () => {
             setIsLoading(false);
             setAssets(data.unusedAssets);
 
-            // TODO: Update currentPage if asset count changes and current page exceeds limit
+            // FIXME: Update currentPage if asset count changes and current page exceeds limit
         }
         // Don't include `isLoading` to prevent constant reloads
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/asset-usage/src/queries/unusedAssetCount.ts
+++ b/packages/asset-usage/src/queries/unusedAssetCount.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 const UNUSED_ASSET_COUNT = gql`
-    query UNUSED_ASSET_COUNT {
-        unusedAssetCount
+    query UNUSED_ASSET_COUNT($assetSourceId: AssetSourceId!) {
+        unusedAssetCount(assetSourceId: $assetSourceId)
     }
 `;
 

--- a/packages/core/src/provider/MediaUiProvider.tsx
+++ b/packages/core/src/provider/MediaUiProvider.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useMemo } from 'react';
 import { gql, useApolloClient } from '@apollo/client';
 import { isMatch } from 'matcher';
+import { useRecoilValue } from 'recoil';
 
 import { useImportAsset } from '../hooks';
 import { useNotify } from './Notify';
@@ -12,7 +13,6 @@ import {
     ApprovalAttainmentStrategyFactory,
     DefaultApprovalAttainmentStrategyFactory,
 } from '../strategy';
-import { useRecoilValue } from 'recoil';
 import { constraintsState } from '../state';
 
 interface MediaUiProviderProps {

--- a/packages/dev-server/src/fixtures/index.ts
+++ b/packages/dev-server/src/fixtures/index.ts
@@ -60,12 +60,14 @@ const assetSources: AssetSource[] = [
 const tags: Tag[] = range(10).map((index) => ({
     __typename: 'Tag',
     id: `index ${index + 1}`,
+    assetSourceId: assetSources[0].id,
     label: `Example tag ${index + 1}`,
 }));
 
 const assetCollections: AssetCollection[] = range(3).map((index) => ({
     __typename: 'AssetCollection',
     id: `someId_${index}`,
+    assetSourceId: assetSources[0].id,
     title: `Example collection ${index + 1}`,
     tags: range(index % 3).map((i) => tags[(i * 3 + index) % tags.length]),
     parent:

--- a/packages/dev-server/src/server.ts
+++ b/packages/dev-server/src/server.ts
@@ -59,7 +59,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
         });
     };
 
-    const sortAssets = (assets: Asset[], sortBy, sortDirection) => {
+    const sortAssets = (assets: Asset[], sortBy: string, sortDirection: string) => {
         const sorted = assets.sort((a, b) => {
             if (sortBy === 'name') {
                 // Using the label here since teh filename is the same in every fixture
@@ -227,6 +227,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
                 const newCollection: AssetCollection = {
                     __typename: 'AssetCollection',
                     id: `someId_${Date.now()}`,
+                    assetSourceId: 'neos',
                     title,
                     parent: parentCollection
                         ? {

--- a/packages/media-module/src/components/SideBarRight/Inspector/AssetCollectionInspector.tsx
+++ b/packages/media-module/src/components/SideBarRight/Inspector/AssetCollectionInspector.tsx
@@ -7,6 +7,7 @@ import { useIntl, useNotify } from '@media-ui/core';
 import { selectedInspectorViewState } from '@media-ui/core/src/state';
 import { useConfigQuery } from '@media-ui/core/src/hooks';
 import { useSelectedAssetCollection, useUpdateAssetCollection } from '@media-ui/feature-asset-collections';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 import { TagSelectBoxAssetCollection } from '.';
 import Actions from './Actions';
@@ -17,6 +18,7 @@ import ParentCollectionSelectBox from './ParentCollectionSelectBox';
 // TASK: Move into media module package
 const AssetCollectionInspector = () => {
     const { config } = useConfigQuery();
+    const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
     const selectedAssetCollection = useSelectedAssetCollection();
     const selectedInspectorView = useRecoilValue(selectedInspectorViewState);
     const Notify = useNotify();
@@ -41,6 +43,7 @@ const AssetCollectionInspector = () => {
         if (title !== selectedAssetCollection.title) {
             updateAssetCollection({
                 assetCollection: selectedAssetCollection,
+                assetSourceId: selectedAssetSourceId,
                 title,
             })
                 .then(() => {
@@ -55,7 +58,7 @@ const AssetCollectionInspector = () => {
                     );
                 });
         }
-    }, [Notify, translate, selectedAssetCollection, updateAssetCollection, title]);
+    }, [title, selectedAssetCollection, updateAssetCollection, selectedAssetSourceId, Notify, translate]);
 
     useEffect(() => {
         handleDiscard();

--- a/packages/media-module/src/components/SideBarRight/Inspector/ParentCollectionSelectBox.tsx
+++ b/packages/media-module/src/components/SideBarRight/Inspector/ParentCollectionSelectBox.tsx
@@ -23,7 +23,7 @@ const ParentCollectionSelectBox = () => {
     const { approvalAttainmentStrategy } = useMediaUi();
     const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
     const { assetCollections } = useAssetCollectionsQuery(selectedAssetSourceId);
-    const selectedAssetCollection = useSelectedAssetCollection(selectedAssetSourceId);
+    const selectedAssetCollection = useSelectedAssetCollection();
     const { setAssetCollectionParent, loading } = useSetAssetCollectionParent();
     const [searchTerm, setSearchTerm] = useState('');
 

--- a/packages/media-module/src/components/SideBarRight/Inspector/ParentCollectionSelectBox.tsx
+++ b/packages/media-module/src/components/SideBarRight/Inspector/ParentCollectionSelectBox.tsx
@@ -14,13 +14,16 @@ import {
 import { AssetCollectionOptionPreviewElement, CollectionOption } from './AssetCollectionOptionPreviewElement';
 
 import * as classes from './ParentCollectionSelectBox.module.css';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
+import { useRecoilValue } from 'recoil';
 
 const ParentCollectionSelectBox = () => {
     const Notify = useNotify();
     const { translate } = useIntl();
     const { approvalAttainmentStrategy } = useMediaUi();
-    const { assetCollections } = useAssetCollectionsQuery();
-    const selectedAssetCollection = useSelectedAssetCollection();
+    const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
+    const { assetCollections } = useAssetCollectionsQuery(selectedAssetSourceId);
+    const selectedAssetCollection = useSelectedAssetCollection(selectedAssetSourceId);
     const { setAssetCollectionParent, loading } = useSetAssetCollectionParent();
     const [searchTerm, setSearchTerm] = useState('');
 
@@ -54,6 +57,7 @@ const ParentCollectionSelectBox = () => {
             if (canMoveCollection && parentCollectionId !== selectedAssetCollection.parent?.id) {
                 setAssetCollectionParent({
                     assetCollection: selectedAssetCollection,
+                    assetSourceId: selectedAssetSourceId,
                     parent: parentCollectionId ? assetCollections.find((c) => c.id === parentCollectionId) : null,
                 })
                     .then(() => {
@@ -79,6 +83,7 @@ const ParentCollectionSelectBox = () => {
             approvalAttainmentStrategy,
             selectedAssetCollection,
             setAssetCollectionParent,
+            selectedAssetSourceId,
             assetCollections,
             Notify,
             translate,

--- a/packages/media-module/src/components/SideBarRight/Inspector/TagInspector.tsx
+++ b/packages/media-module/src/components/SideBarRight/Inspector/TagInspector.tsx
@@ -8,12 +8,14 @@ import { useIntl, useNotify } from '@media-ui/core';
 import { useConfigQuery } from '@media-ui/core/src/hooks';
 import { selectedInspectorViewState } from '@media-ui/core/src/state';
 import { useSelectedTag, useUpdateTag } from '@media-ui/feature-asset-tags';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 import Actions from './Actions';
 import Property from './Property';
 import InspectorContainer from './InspectorContainer';
 
 const TagInspector = () => {
+    const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
     const selectedTag = useSelectedTag();
     const selectedInspectorView = useRecoilValue(selectedInspectorViewState);
     const Notify = useNotify();
@@ -35,6 +37,7 @@ const TagInspector = () => {
         if (label !== selectedTag.label) {
             updateTag({
                 tag: selectedTag,
+                assetSourceId: selectedAssetSourceId,
                 label,
             })
                 .then(() => {
@@ -44,7 +47,7 @@ const TagInspector = () => {
                     Notify.error(translate('actions.updateTag.error', 'Error while updating the tag'), message);
                 });
         }
-    }, [Notify, translate, selectedTag, updateTag, label]);
+    }, [label, selectedTag, updateTag, selectedAssetSourceId, Notify, translate]);
 
     useEffect(() => {
         handleDiscard();

--- a/packages/media-module/src/components/SideBarRight/Inspector/TagSelectBoxAsset.tsx
+++ b/packages/media-module/src/components/SideBarRight/Inspector/TagSelectBoxAsset.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback, useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { useIntl, useMediaUi, useNotify } from '@media-ui/core';
 import { useSelectedAsset, useSetAssetTags } from '@media-ui/core/src/hooks';
 import { useTagsQuery } from '@media-ui/feature-asset-tags';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 import { TagSelectBox } from '.';
 
@@ -25,7 +27,8 @@ const TagSelectBoxAsset = () => {
     const {
         approvalAttainmentStrategy: { obtainApprovalToSetAssetTags },
     } = useMediaUi();
-    const { tags: allTags } = useTagsQuery();
+    const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
+    const { tags: allTags } = useTagsQuery(selectedAssetSourceId);
     const { setAssetTags, loading } = useSetAssetTags();
     const selectedAsset = useSelectedAsset();
 

--- a/packages/media-module/src/components/SideBarRight/Inspector/TagSelectBoxAssetCollection.tsx
+++ b/packages/media-module/src/components/SideBarRight/Inspector/TagSelectBoxAssetCollection.tsx
@@ -6,6 +6,8 @@ import { useTagsQuery } from '@media-ui/feature-asset-tags';
 import { useSelectedAssetCollection, useUpdateAssetCollection } from '@media-ui/feature-asset-collections';
 
 import { TagSelectBox } from '.';
+import { useRecoilValue } from 'recoil';
+import { selectedAssetSourceState } from '@media-ui/feature-asset-sources';
 
 const tagsMatchAssetCollection = (tags: Tag[], assetCollection: AssetCollection) => {
     return (
@@ -24,7 +26,8 @@ const TagSelectBoxAssetCollection = () => {
     const Notify = useNotify();
     const { config } = useConfigQuery();
     const { translate } = useIntl();
-    const { tags: allTags } = useTagsQuery();
+    const selectedAssetSourceId = useRecoilValue(selectedAssetSourceState);
+    const { tags: allTags } = useTagsQuery(selectedAssetSourceId);
     const { updateAssetCollection } = useUpdateAssetCollection();
     const selectedAssetCollection = useSelectedAssetCollection();
 
@@ -38,6 +41,7 @@ const TagSelectBoxAssetCollection = () => {
             if (!tagsMatchAssetCollection(newTags, selectedAssetCollection)) {
                 updateAssetCollection({
                     assetCollection: selectedAssetCollection,
+                    assetSourceId: selectedAssetSourceId,
                     tags: newTags,
                 })
                     .then(() => {
@@ -53,7 +57,7 @@ const TagSelectBoxAssetCollection = () => {
                     });
             }
         },
-        [Notify, selectedAssetCollection, updateAssetCollection, translate]
+        [selectedAssetCollection, updateAssetCollection, selectedAssetSourceId, Notify, translate]
     );
 
     if (!selectedAssetCollection) return null;

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -9,4 +9,4 @@ parameters:
         - '#Call to an undefined method [a-zA-Z0-9\\_]+Repository::findOneBy[a-zA-Z]+\(\)#'
         - '#Constant FLOW_PATH_DATA not found.#'
     scanDirectories:
-        - ../../Framework/Neos.Flow/Tests
+        - Packages/Framework/Neos.Flow/Tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,6 @@ parameters:
     phpVersion: 80300
     paths:
         - Classes
-    bootstrapFiles:
-        - vendor/autoload.php
     ignoreErrors:
         - '#Call to an undefined method [a-zA-Z0-9\\_]+Repository::findBy[a-zA-Z]+\(\)#'
         - '#Call to an undefined method [a-zA-Z0-9\\_]+Repository::findOneBy[a-zA-Z]+\(\)#'


### PR DESCRIPTION
This allows us in the future to check the asset source for capabilities and let the asset source give us the data we need or execute the mutations.
This is especially necessary for content repository backed asset sources.