### PR TITLE
Authenticate sessionless tokens

### DIFF
--- a/Classes/GraphQL/Middleware/GraphQLMiddleware.php
+++ b/Classes/GraphQL/Middleware/GraphQLMiddleware.php
@@ -34,7 +34,6 @@ use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Context;
-use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/Classes/GraphQL/Middleware/GraphQLMiddleware.php
+++ b/Classes/GraphQL/Middleware/GraphQLMiddleware.php
@@ -81,16 +81,10 @@ final class GraphQLMiddleware implements MiddlewareInterface
         }
         if ($this->simulateControllerObjectName !== null) {
             $mockActionRequest = ActionRequest::fromHttpRequest($request);
-            // Simulate a request to the specified controller to trigger authentication
+            // Simulate a request to the specified controller
             $mockActionRequest->setControllerObjectName($this->simulateControllerObjectName);
             $this->securityContext->setRequest($mockActionRequest);
-            try {
-                $this->authenticationManager->authenticate();
-            } catch (AuthenticationRequiredException) {
-                // Explicit call so sessionless tokens (e.g. OIDC/JWT) get authenticated.
-                // Unauthenticated requests are not rejected here but continue anonymously.
-                // The privilege targets decide whether they may access anything.
-            }
+            $this->authenticationManager->isAuthenticated();  // Trigger authentication if isAuthenticated is null
         }
         $response = $this->responseFactory->createResponse();
         $response = $this->addCorsHeaders($response);

--- a/Classes/GraphQL/Middleware/GraphQLMiddleware.php
+++ b/Classes/GraphQL/Middleware/GraphQLMiddleware.php
@@ -32,7 +32,9 @@ use Neos\Flow\Exception as FlowException;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Context;
+use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -66,6 +68,7 @@ final class GraphQLMiddleware implements MiddlewareInterface
         private readonly ContainerInterface $serviceLocator,
         private readonly CustomResolvers $customResolvers,
         private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly AuthenticationManagerInterface $authenticationManager,
     ) {
     }
 
@@ -81,6 +84,13 @@ final class GraphQLMiddleware implements MiddlewareInterface
             // Simulate a request to the specified controller to trigger authentication
             $mockActionRequest->setControllerObjectName($this->simulateControllerObjectName);
             $this->securityContext->setRequest($mockActionRequest);
+            try {
+                $this->authenticationManager->authenticate();
+            } catch (AuthenticationRequiredException) {
+                // Explicit call so sessionless tokens (e.g. OIDC/JWT) get authenticated.
+                // Unauthenticated requests are not rejected here but continue anonymously.
+                // The privilege targets decide whether they may access anything.
+            }
         }
         $response = $this->responseFactory->createResponse();
         $response = $this->addCorsHeaders($response);

--- a/Classes/GraphQL/Middleware/GraphQLMiddlewareFactory.php
+++ b/Classes/GraphQL/Middleware/GraphQLMiddlewareFactory.php
@@ -22,6 +22,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Context;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -40,6 +41,7 @@ final class GraphQLMiddlewareFactory
         private readonly ObjectManagerInterface $objectManager,
         private readonly CustomResolversFactory $customResolversFactory,
         private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly AuthenticationManagerInterface $authenticationManager,
     ) {
     }
 
@@ -65,6 +67,7 @@ final class GraphQLMiddlewareFactory
             $this->objectManager,
             $this->customResolversFactory->create($customResolversSettings ?? []),
             $this->persistenceManager,
+            $this->authenticationManager,
         );
     }
 }


### PR DESCRIPTION
My attempt to resolve: #305

This change injects the `AuthenticationManagerInterface` via the `GraphQLMiddlewareFactory` and calls `authenticate()` after the simulated request is assigned. 
`AuthenticationRequiredException` is caught deliberately:
Authentication is attempted, not required, so anonymous/token-based API access (as described in the README) keeps working and privilege targets decide authorization as before.


Tested with:
flowpack/media-ui: 2.0.4
flownative/openidconnect-neos: 0.4.0
flownative/neos-canto: 0.6.0