### PR TITLE
BUGFIX: Fix Policy to properly trigger authentication for GraphQL queries/mutations

### DIFF
--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -11,7 +11,7 @@ privilegeTargets:
       matcher: 'method(Flowpack\Media\Ui\GraphQL\Resolver\Type\MutationResolver->(create|delete|update)AssetCollection())'
     'Flowpack.Media.Ui:Queries':
       label: 'Query asset data'
-      matcher: 'method(public Flowpack\Media\Ui\GraphQL\Resolver\(.*)Resolver->.*()) || method(public Flowpack\Media\Ui\GraphQL\MediaApi->.*())'
+      matcher: 'method(public Flowpack\Media\Ui\GraphQL\Resolver\(.*)Resolver->.*()) || method(public Flowpack\Media\Ui\GraphQL\MediaApi->(?!__construct).*())'
 
   'Neos\Neos\Security\Authorization\Privilege\ModulePrivilege':
     'Flowpack.Media.Ui:Backend.Module.Management.Media':

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -11,7 +11,7 @@ privilegeTargets:
       matcher: 'method(Flowpack\Media\Ui\GraphQL\Resolver\Type\MutationResolver->(create|delete|update)AssetCollection())'
     'Flowpack.Media.Ui:Queries':
       label: 'Query asset data'
-      matcher: 'method(public Flowpack\Media\Ui\GraphQL\Resolver\(.*)Resolver->.*()) || method(t3n\GraphQL\Controller\GraphQLController->queryAction())'
+      matcher: 'method(public Flowpack\Media\Ui\GraphQL\Resolver\(.*)Resolver->.*()) || method(public Flowpack\Media\Ui\GraphQL\MediaApi->.*())'
 
   'Neos\Neos\Security\Authorization\Privilege\ModulePrivilege':
     'Flowpack.Media.Ui:Backend.Module.Management.Media':


### PR DESCRIPTION
`Policy.yaml` still referred to some no-longer used `t3n\GraphQL` namespace. By fixing the method privilege matcher to point to public methods of the `MediaApi` class, the [PolicyEnforcementAspect](https://github.com/neos/flow-development-collection/blob/1956920c41b5eb9348daaaf03543efaa45b098b2/Neos.Flow/Classes/Security/Aspect/PolicyEnforcementAspect.php) is properly invoked, triggering authentication.

Fixes: #305
