### PR TITLE
BUGFIX: Update PHPUnit tests to v11 to match core dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.3']
-        flow-versions: ['8.3']
+        flow-versions: ['8.4']
 
     steps:
       - uses: actions/checkout@v5
@@ -101,6 +101,7 @@ jobs:
           cd ${FLOW_FOLDER}
           composer require --no-update --no-interaction flowpack/entity-usage:"^1.1"
           composer require --no-update --no-interaction flowpack/entity-usage-databasestorage:"^0.1"
+          composer require --no-update --dev --no-interaction phpunit/phpunit:"^11.0"
 
           git -C ../${{ env.PACKAGE_FOLDER }} checkout -b build
           composer config repositories.package '{ "type": "path", "url": "../${{ env.PACKAGE_FOLDER }}", "options": { "symlink": false } }'
@@ -109,7 +110,7 @@ jobs:
       - name: Composer Install
         run: |
           cd ${FLOW_FOLDER}
-          composer update --no-interaction --no-progress
+          composer install --no-interaction --no-progress
 
       - name: Run Unit tests
         run: |
@@ -134,7 +135,7 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
 
-      - name: Run mocha tests
+      - name: Run JS unit tests
         run: yarn test:unit
 
   e2e:

--- a/Tests/Functional/AbstractMediaTestCase.php
+++ b/Tests/Functional/AbstractMediaTestCase.php
@@ -35,7 +35,7 @@ abstract class AbstractMediaTestCase extends FunctionalTestCase
      */
     protected $resourceManager;
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $persistenceManager = self::$bootstrap->getObjectManager()->get(PersistenceManagerInterface::class);
         if (is_callable([$persistenceManager, 'tearDown'])) {
@@ -63,7 +63,7 @@ abstract class AbstractMediaTestCase extends FunctionalTestCase
      */
     protected function createMockResourceAndPointerFromHash(string $hash): PersistentResource
     {
-        $mockResource = $this->getMockBuilder(PersistentResource::class)->setMethods(['getHash', 'getUri'])->getMock();
+        $mockResource = $this->getMockBuilder(PersistentResource::class)->addMethods(['getHash', 'getUri'])->getMock();
         $mockResource
                 ->method('getHash')
                 ->willReturn($hash);

--- a/Tests/Functional/Domain/Model/AssetCollectionTest.php
+++ b/Tests/Functional/Domain/Model/AssetCollectionTest.php
@@ -37,7 +37,7 @@ class AssetCollectionTest extends AbstractMediaTestCase
      */
     protected $assetCollectionService;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Tests/Functional/Domain/Repository/AssetCollectionRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/AssetCollectionRepositoryTest.php
@@ -32,7 +32,7 @@ class AssetCollectionRepositoryTest extends AbstractMediaTestCase
 
     protected AssetCollectionRepository $assetCollectionRepository;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Tests/Functional/GraphQL/AssetApiTest.php
+++ b/Tests/Functional/GraphQL/AssetApiTest.php
@@ -43,7 +43,7 @@ class AssetApiTest extends AbstractMediaTestCase
     protected AssetRepository $assetRepository;
     protected false $isolated;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->isolated = false;
@@ -134,7 +134,7 @@ class AssetApiTest extends AbstractMediaTestCase
 
         $this->assertTrue($deleteResult->success);
         $assetsAfterDeletion = $this->mediaApi->assets(Types\AssetSourceId::default());
-        $this->assertCount(0, $assetsAfterDeletion);
+        $this->assertCount(0, $assetsAfterDeletion->assets);
     }
 
     public function testDeleteUsedAssetFails(): void
@@ -158,7 +158,7 @@ class AssetApiTest extends AbstractMediaTestCase
 
         $this->assertFalse($deleteResult->success);
         $assetsAfterDeletion = $this->mediaApi->assets(Types\AssetSourceId::default());
-        $this->assertCount(1, $assetsAfterDeletion);
+        $this->assertCount(1, $assetsAfterDeletion->assets);
     }
 
     public function testUpdateAsset(): void
@@ -308,7 +308,7 @@ class AssetApiTest extends AbstractMediaTestCase
 
         $unusedAssets = $this->mediaApi->unusedAssets(Types\AssetSourceId::default());
         $unusedAsset = $unusedAssets->assets[0];
-        $this->assertCount(1, $unusedAssets);
+        $this->assertCount(1, $unusedAssets->assets);
         $this->assertEquals($file->clientFilename, $unusedAsset->filename->value);
     }
 }

--- a/Tests/Functional/GraphQL/AssetCollectionApiTest.php
+++ b/Tests/Functional/GraphQL/AssetCollectionApiTest.php
@@ -33,7 +33,7 @@ class AssetCollectionApiTest extends AbstractMediaTestCase
     protected MediaApi $mediaApi;
     protected AssetCollectionResolver $assetCollectionResolver;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Tests/Functional/GraphQL/TagApiTest.php
+++ b/Tests/Functional/GraphQL/TagApiTest.php
@@ -35,7 +35,7 @@ class TagApiTest extends AbstractMediaTestCase
     protected AssetCollectionResolver $assetCollectionResolver;
     protected AssetResolver $assetResolver;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Tests/Unit/Domain/Model/SearchTermTest.php
+++ b/Tests/Unit/Domain/Model/SearchTermTest.php
@@ -45,7 +45,7 @@ final class SearchTermTest extends UnitTestCase
     /**
      * @return array<mixed>
      */
-    public function nonStringValueExamples(): array
+    public static function nonStringValueExamples(): array
     {
         return [
             'null' => [null],

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "wwwision/types-graphql": "^1.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^11.0",
     "phpstan/phpstan": "^1.12 || ^2"
   },
   "suggest": {


### PR DESCRIPTION
Neos 8.4 now uses PHPUnit 11 and Neos 8.3 version 9, so the unit tests don't work anymore with both versions.
So for now we focus in the CI to make them work in Neos 8.3 which is the lowest supported version.