### PR TITLE
FEATURE: Render asset usage counter inside inspector action buttons

### DIFF
--- a/packages/asset-usage/src/components/AssetUsageSection.module.css
+++ b/packages/asset-usage/src/components/AssetUsageSection.module.css
@@ -9,6 +9,8 @@
     width: 100%;
     margin-top: var(--theme-spacing-Full);
     line-height: 1.5;
+    border-collapse: separate;
+    border-spacing: 0;
 }
 
 .usageTable th {
@@ -18,17 +20,13 @@
 
 .usageTable td,
 .usageTable th {
-    padding: var(--theme-spacing-Quarter);
+    padding: 0 var(--theme-spacing-Half);
+    height: var(--theme-unit);
 }
 
-.usageTable td:first-child,
-.usageTable th:first-child {
-    padding-left: 0;
-}
-
-.usageTable td:last-child,
-.usageTable th:last-child {
-    padding-right: 0;
+.usageTable td {
+    border-top: 1px solid var(--theme-colors-ContrastDarker);
+    background-color: var(--theme-colors-ContrastNeutral);
 }
 
 /* This is for specificity; otherwise `.neos.neos-module a` would override this link style in the backend module */

--- a/packages/asset-usage/src/components/AssetUsagesToggleButton.module.css
+++ b/packages/asset-usage/src/components/AssetUsagesToggleButton.module.css
@@ -1,0 +1,3 @@
+.assetUsageBadge {
+    color: var(--theme-blue);
+}

--- a/packages/asset-usage/src/components/AssetUsagesToggleButton.tsx
+++ b/packages/asset-usage/src/components/AssetUsagesToggleButton.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { useRecoilState } from 'recoil';
 
-import { Button, Icon } from '@neos-project/react-ui-components';
+import { Badge, Button, Icon } from '@neos-project/react-ui-components';
 
 import { useIntl } from '@media-ui/core';
 import { useSelectedAsset } from '@media-ui/core/src/hooks';
 
 import assetUsageDetailsModalState from '../state/assetUsageDetailsModalState';
+import useAssetUsagesQuery from '@media-ui/feature-asset-usage/src/hooks/useAssetUsages';
+
+import classes from './AssetUsagesToggleButton.module.css';
 
 interface AssetUsagesToggleButtonProps {
     variant?: 'button' | 'menuItem';
@@ -19,10 +22,13 @@ const AssetUsagesToggleButton: React.FC<AssetUsagesToggleButtonProps> = ({
     menuItemClassName,
     menuItemDisabledClassName,
 }) => {
-    const { isInUse } = useSelectedAsset();
+    const asset = useSelectedAsset();
+    const { assetUsageDetails } = useAssetUsagesQuery(
+        asset ? { assetId: asset.id, assetSourceId: asset.assetSource.id } : null
+    );
     const [assetUsagesModalOpen, setAssetUsagesModalOpen] = useRecoilState(assetUsageDetailsModalState);
     const { translate } = useIntl();
-    const disabled = isInUse === false;
+    const disabled = asset.isInUse === false;
     const label = translate('assetUsageList.toggle', 'Show usages');
 
     if (variant === 'menuItem') {
@@ -33,6 +39,11 @@ const AssetUsagesToggleButton: React.FC<AssetUsagesToggleButtonProps> = ({
             >
                 <Icon icon="link" />
                 <span>{label}</span>
+                {assetUsageDetails?.[0]?.usages ? (
+                    <Badge label={assetUsageDetails[0].usages.length} className={classes.assetUsageBadge} />
+                ) : (
+                    ''
+                )}
             </li>
         );
     }
@@ -47,6 +58,11 @@ const AssetUsagesToggleButton: React.FC<AssetUsagesToggleButtonProps> = ({
             title={label}
         >
             <Icon icon="link" />
+            {assetUsageDetails?.[0]?.usages ? (
+                <Badge label={assetUsageDetails[0].usages.length} className={classes.assetUsageBadge} />
+            ) : (
+                ''
+            )}
         </Button>
     );
 };

--- a/packages/media-module/src/components/SideBarRight/Inspector/TaskMenuItem.module.css
+++ b/packages/media-module/src/components/SideBarRight/Inspector/TaskMenuItem.module.css
@@ -15,7 +15,7 @@
     color: white !important;
 }
 
-.menuItem--disabled {
+.menuItemDisabled {
     opacity: 0.5;
     cursor: not-allowed;
     pointer-events: none;

--- a/packages/media-module/src/components/SideBarRight/Inspector/Tasks.tsx
+++ b/packages/media-module/src/components/SideBarRight/Inspector/Tasks.tsx
@@ -81,7 +81,7 @@ const Tasks: React.FC = () => {
                         <AssetUsagesToggleButton
                             variant="menuItem"
                             menuItemClassName={menuItemClasses.menuItem}
-                            menuItemDisabledClassName={menuItemClasses['menuItem--disabled']}
+                            menuItemDisabledClassName={menuItemClasses.menuItemDisabled}
                         />
                         {showSimilarAssets && (
                             <SimilarAssetsToggleButton
@@ -93,7 +93,7 @@ const Tasks: React.FC = () => {
                             assets={[selectedAsset]}
                             variant="menuItem"
                             menuItemClassName={menuItemClasses.menuItem}
-                            menuItemDisabledClassName={menuItemClasses['menuItem--disabled']}
+                            menuItemDisabledClassName={menuItemClasses.menuItemDisabled}
                         />
                         {!isReadonly && applicationContext !== 'details' && (
                             <>


### PR DESCRIPTION
Rebased PR by @soee see #221 

**What I did**

- i have extended `AssetUsageToggleButton` component to show also asset udage counter
- i have modified `AssetUsageSection` styles so the table rendered inside dialog window looks a bit better

**How I did it**
- i have modified `AssetUsageToggleButton` and `AssetUsageSection` components
- i have modified CSS

**How to verify it**

- go to Media module
- select some asset with or without usages
- for asset with usages set, you should see badge with number on the `Show usgaes` button inside inspector actions/tasks
- if you open dialog with usages, you should see re-styled table with usage items

**If asset has no usages**

![image](https://github.com/Flowpack/media-ui/assets/1798417/071e23fc-8be1-45b1-be3c-fdb7c7b8c93c)

**If asset has usages**

![image](https://github.com/Flowpack/media-ui/assets/1798417/e9c7ac17-ed9e-41e6-8f61-59aebaa75828)

**Table inside modal with asset usages**

before

![image](https://github.com/Flowpack/media-ui/assets/1798417/2e82389b-4ac6-4abb-8de3-a605651a95d4)

after

![image](https://github.com/Flowpack/media-ui/assets/1798417/3a4e65ab-a677-466b-82d2-bbcdd3f4033c)
